### PR TITLE
ConnectionFactory Discovery

### DIFF
--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Assert.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Assert.java
@@ -17,11 +17,27 @@
 package io.r2dbc.spi;
 
 /**
- * Non-public assertion library for SPI testing.
+ * Non-public assertion library for SPI implementations.
  */
 abstract class Assert {
 
     private Assert() {
+    }
+
+    /**
+     * Checks that a specified {@link String} is not empty and throws a customized {@link IllegalArgumentException} if it is.
+     *
+     * @param s       the {@link String} to check for emptiness
+     * @param message the detail message to be used in the event that an {@link IllegalArgumentException} is thrown
+     * @return {@code s} if not empty
+     * @throws IllegalArgumentException if {@code s} is empty
+     */
+    static String requireNonEmpty(String s, String message) {
+        if (s.isEmpty()) {
+            throw new IllegalArgumentException(message);
+        }
+
+        return s;
     }
 
     /**

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactories.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactories.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ServiceLoader;
+
+/**
+ * Utility for discovering an available {@link ConnectionFactory} based on a set of {@link ConnectionFactoryOptions}.
+ */
+public final class ConnectionFactories {
+
+    /**
+     * Returns a {@link ConnectionFactory} if an available implementation can be created from a collection of {@link ConnectionFactoryOptions}.
+     *
+     * @param connectionFactoryOptions a collection of {@link ConnectionFactoryOptions}
+     * @return the created {@link ConnectionFactory} if one can be created, otherwise {@code null}
+     * @throws IllegalArgumentException if {@code connectionSpecification} is {@code null}
+     */
+    @Nullable
+    public ConnectionFactory find(ConnectionFactoryOptions connectionFactoryOptions) {
+        Assert.requireNonNull(connectionFactoryOptions, "connectionFactoryOptions must not be null");
+
+        for (ConnectionFactoryProvider provider : loadProviders()) {
+            if (provider.supports(connectionFactoryOptions)) {
+                return provider.create(connectionFactoryOptions);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns a {@link ConnectionFactory} from an available implementation, created from a collection of {@link ConnectionFactoryOptions}.
+     *
+     * @param connectionFactoryOptions a collection of {@link ConnectionFactoryOptions}
+     * @return the created {@link ConnectionFactory}
+     * @throws IllegalArgumentException if {@code connectionFactoryOptions} is {@code null}
+     * @throws IllegalStateException    if no available implementation can create a {@link ConnectionFactory}
+     */
+    public ConnectionFactory get(ConnectionFactoryOptions connectionFactoryOptions) {
+        ConnectionFactory connectionFactory = find(connectionFactoryOptions);
+
+        if (connectionFactory == null) {
+            throw new IllegalStateException(String.format("Unable to create a ConnectionFactory for '%s'", connectionFactoryOptions));
+        }
+
+        return connectionFactory;
+    }
+
+    /**
+     * Returns whether a {@link ConnectionFactory} can be created from a collection of {@link ConnectionFactoryOptions}.
+     *
+     * @param connectionFactoryOptions a collection of {@link ConnectionFactoryOptions}
+     * @return {@code true} if a {@link ConnectionFactory} can be created from a collection of {@link ConnectionFactoryOptions}, {@code false} otherwise.
+     * @throws IllegalArgumentException if {@code connectionFactoryOptions} is {@code null}
+     */
+    public boolean supports(ConnectionFactoryOptions connectionFactoryOptions) {
+        Assert.requireNonNull(connectionFactoryOptions, "connectionFactoryOptions must not be null");
+
+        for (ConnectionFactoryProvider provider : loadProviders()) {
+            if (provider.supports(connectionFactoryOptions)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private ServiceLoader<ConnectionFactoryProvider> loadProviders() {
+        return AccessController.doPrivileged((PrivilegedAction<ServiceLoader<ConnectionFactoryProvider>>) () -> ServiceLoader.load(ConnectionFactoryProvider.class,
+            ConnectionFactoryProvider.class.getClassLoader()));
+    }
+
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A holder for configuration options related to {@link ConnectionFactory}s.
+ */
+public final class ConnectionFactoryOptions {
+
+    /**
+     * Connection timeout.
+     */
+    public static final Option<Duration> CONNECT_TIMEOUT = Option.valueOf("connectTimeout");
+
+    /**
+     * Initial database name.
+     */
+    public static final Option<String> DATABASE = Option.valueOf("database");
+
+    /**
+     * Driver name.
+     */
+    public static final Option<String> DRIVER = Option.valueOf("driver");
+
+    /**
+     * Endpoint host name.
+     */
+    public static final Option<String> HOST = Option.valueOf("host");
+
+    /**
+     * Password for authentication.
+     */
+    public static final Option<CharSequence> PASSWORD = Option.valueOf("password");
+
+    /**
+     * Endpoint port number.
+     */
+    public static final Option<Integer> PORT = Option.valueOf("port");
+
+    /**
+     * Driver protocol name. Typically represented as {@code tcp} or a database vendor-specific protocol string.
+     */
+    public static final Option<String> PROTOCOL = Option.valueOf("protocol");
+
+    /**
+     * Whether to require SSL.
+     */
+    public static final Option<Boolean> SSL = Option.valueOf("ssl");
+
+    /**
+     * User for authentication.
+     */
+    public static final Option<String> USER = Option.valueOf("user");
+
+    private final Map<Option<?>, ?> options;
+
+    private ConnectionFactoryOptions(Map<Option<?>, ?> options) {
+        this.options = Assert.requireNonNull(options, "options must not be null");
+    }
+
+    /**
+     * Returns a new {@link Builder}.
+     *
+     * @return a new {@link Builder}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Returns the value for an option if it exists.
+     *
+     * @param option the option to retrieve the value for
+     * @param <T>    the type of the value
+     * @return the value for an option
+     * @throws IllegalArgumentException if {@code option} is {@code null}
+     * @throws IllegalStateException    if there is no value for {@code option}
+     */
+    public <T> T getRequiredValue(Option<T> option) {
+        T value = getValue(option);
+
+        if (value != null) {
+            return value;
+        }
+
+        throw new IllegalStateException(String.format("No value found for %s", option.name()));
+    }
+
+    /**
+     * Returns the value for an option if it exists, otherwise {@code null}.
+     *
+     * @param option the option to retrieve the value for
+     * @param <T>    the type of the value
+     * @return the value for an option if it exists, otherwise {@code null}
+     * @throws IllegalArgumentException if {@code option} is {@code null}
+     */
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public <T> T getValue(Option<T> option) {
+        Assert.requireNonNull(option, "option must not be null");
+
+        return (T) this.options.get(option);
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectionFactoryOptions{" +
+            "options=" + this.options +
+            '}';
+    }
+
+    /**
+     * A builder for {@link ConnectionFactoryOptions} isntances.
+     * <p>
+     * <i>This class is not threadsafe</i>
+     */
+    public static final class Builder {
+
+        private final Map<Option<?>, Object> options = new HashMap<>();
+
+        private Builder() {
+        }
+
+        /**
+         * Returns a configured {@link ConnectionFactoryOptions}.
+         *
+         * @return a configured {@link ConnectionFactoryOptions}
+         */
+        public ConnectionFactoryOptions build() {
+            return new ConnectionFactoryOptions(new HashMap<>(this.options));
+        }
+
+        /**
+         * Configure an {@link Option} value.
+         *
+         * @param option the {@link Option} to configure
+         * @param value  the {@link Option}'s value
+         * @param <T>    the type of the value
+         * @return this {@link Builder}
+         * @throws IllegalArgumentException if {@code option} or {@code value} are {@code null}
+         */
+        public <T> Builder option(Option<T> option, T value) {
+            Assert.requireNonNull(option, "option must not be null");
+            Assert.requireNonNull(value, "value must not be null");
+
+            this.options.put(option, value);
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "Builder{" +
+                "options=" + this.options +
+                '}';
+        }
+
+    }
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryProvider.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+/**
+ * A Java Service interface for implementations to examine a collection of {@link ConnectionFactoryOptions} and optionally return an implementation of {@link ConnectionFactory}.
+ */
+public interface ConnectionFactoryProvider {
+
+    /**
+     * Creates a new {@link ConnectionFactory} given a collection of {@link ConnectionFactoryOptions}.  This method is only called if a previous invocation of
+     * {@link #supports(ConnectionFactoryOptions)} has returned {@code true}.
+     *
+     * @param connectionFactoryOptions a collection of {@link ConnectionFactoryOptions}
+     * @return the {@link ConnectionFactory} created from this collection of {@link ConnectionFactoryOptions}
+     * @throws IllegalArgumentException if {@code connectionFactoryOptions} is {@code null}
+     */
+    ConnectionFactory create(ConnectionFactoryOptions connectionFactoryOptions);
+
+    /**
+     * Whether this {@link ConnectionFactoryProvider} supports this collection of {@link ConnectionFactoryOptions}.
+     *
+     * @param connectionFactoryOptions a collection of {@link ConnectionFactoryOptions}
+     * @return {@code true} if this {@link ConnectionFactoryProvider} supports this collection of {@link ConnectionFactoryOptions}, {@code false} otherwise
+     * @throws IllegalArgumentException if {@code connectionFactoryOptions} is {@code null}
+     */
+    boolean supports(ConnectionFactoryOptions connectionFactoryOptions);
+
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConstantPool.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConstantPool.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A pool of constant instances.  Only a single instance of each constant (by name) should ever exist.
+ *
+ * @param <T> the type of the constant
+ */
+abstract class ConstantPool<T> {
+
+    private final ConcurrentMap<String, T> constants = new ConcurrentHashMap<>();
+
+    @Override
+    public String toString() {
+        return "ConstantPool{" +
+            "constants=" + this.constants +
+            '}';
+    }
+
+    /**
+     * Creates a new instance of the constant.  Implementations of this method should return a new instance each time.
+     *
+     * @param name the name of the constant
+     * @return a new instance of the constant
+     */
+    abstract T createConstant(String name);
+
+    /**
+     * Returns a cached or newly created instance of a constant.
+     *
+     * @param name the name of the constant
+     * @return a cached or newly created instance of a constant
+     * @throws IllegalArgumentException if {@code name} is {@code null} or empty
+     */
+    final T valueOf(String name) {
+        Assert.requireNonNull(name, "name must not be null");
+        Assert.requireNonEmpty(name, "name must not be empty");
+
+        return this.constants.computeIfAbsent(name, this::createConstant);
+    }
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConstantPool.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConstantPool.java
@@ -38,22 +38,24 @@ abstract class ConstantPool<T> {
     /**
      * Creates a new instance of the constant.  Implementations of this method should return a new instance each time.
      *
-     * @param name the name of the constant
+     * @param name      the name of the constant
+     * @param sensitive whether the value represented by this constant is sensitive
      * @return a new instance of the constant
      */
-    abstract T createConstant(String name);
+    abstract T createConstant(String name, boolean sensitive);
 
     /**
      * Returns a cached or newly created instance of a constant.
      *
-     * @param name the name of the constant
+     * @param name      the name of the constant
+     * @param sensitive whether the value represented by this constant is sensitive
      * @return a cached or newly created instance of a constant
      * @throws IllegalArgumentException if {@code name} is {@code null} or empty
      */
-    final T valueOf(String name) {
+    final T valueOf(String name, boolean sensitive) {
         Assert.requireNonNull(name, "name must not be null");
         Assert.requireNonEmpty(name, "name must not be empty");
 
-        return this.constants.computeIfAbsent(name, this::createConstant);
+        return this.constants.computeIfAbsent(name, n -> createConstant(n, sensitive));
     }
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Option.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Option.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+/**
+ * Represents a configuration option constant.
+ *
+ * @param <T> The value type of the option
+ */
+public final class Option<T> {
+
+    private static final ConstantPool<Option<?>> CONSTANTS = new ConstantPool<Option<?>>() {
+
+        @Override
+        Option<?> createConstant(String name) {
+            return new Option<>(name);
+        }
+
+    };
+
+    private final String name;
+
+    private Option(String name) {
+        this.name = Assert.requireNonNull(name, "name must not be null");
+    }
+
+    /**
+     * Returns a constant singleton instance of the option.
+     *
+     * @param name the name of the option to return
+     * @param <T>  the value type of the option
+     * @return a constant singleton instance of the option
+     * @throws IllegalArgumentException if {@code name} is {@code null} or empty
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Option<T> valueOf(String name) {
+        Assert.requireNonNull(name, "name must not be null");
+        Assert.requireNonEmpty(name, "name must not be empty");
+
+        return (Option<T>) CONSTANTS.valueOf(name);
+    }
+
+    /**
+     * Returns the name of the option.
+     *
+     * @return the name of the option
+     */
+    public String name() {
+        return this.name;
+    }
+
+    @Override
+    public String toString() {
+        return "Option{" +
+            "name='" + this.name + '\'' +
+            '}';
+    }
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Option.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Option.java
@@ -26,16 +26,35 @@ public final class Option<T> {
     private static final ConstantPool<Option<?>> CONSTANTS = new ConstantPool<Option<?>>() {
 
         @Override
-        Option<?> createConstant(String name) {
-            return new Option<>(name);
+        Option<?> createConstant(String name, boolean sensitive) {
+            return new Option<>(name, sensitive);
         }
 
     };
 
     private final String name;
 
-    private Option(String name) {
-        this.name = Assert.requireNonNull(name, "name must not be null");
+    private final boolean sensitive;
+
+    private Option(String name, boolean sensitive) {
+        this.name = name;
+        this.sensitive = sensitive;
+    }
+
+    /**
+     * Returns a constant singleton instance of the sensitive option.
+     *
+     * @param name the name of the option to return
+     * @param <T>  the value type of the option
+     * @return a constant singleton instance of the option
+     * @throws IllegalArgumentException if {@code name} is {@code null} or empty
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Option<T> sensitiveValueOf(String name) {
+        Assert.requireNonNull(name, "name must not be null");
+        Assert.requireNonEmpty(name, "name must not be empty");
+
+        return (Option<T>) CONSTANTS.valueOf(name, true);
     }
 
     /**
@@ -51,7 +70,7 @@ public final class Option<T> {
         Assert.requireNonNull(name, "name must not be null");
         Assert.requireNonEmpty(name, "name must not be empty");
 
-        return (Option<T>) CONSTANTS.valueOf(name);
+        return (Option<T>) CONSTANTS.valueOf(name, false);
     }
 
     /**
@@ -66,7 +85,12 @@ public final class Option<T> {
     @Override
     public String toString() {
         return "Option{" +
-            "name='" + this.name + '\'' +
+            "name='" + name + '\'' +
+            ", sensitive=" + sensitive +
             '}';
+    }
+
+    boolean sensitive() {
+        return this.sensitive;
     }
 }


### PR DESCRIPTION
This change adds support for discovering ConnectionFactory implementations using an opaque connection specification and the Java ServiceLoader functionality.  In addition to the interface implementations would provider, there is a utility for returning a ConnectionFactory given the connection specification.