### PR TITLE
Retrieve Generated Keys

### DIFF
--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockStatement.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockStatement.java
@@ -21,6 +21,7 @@ import io.r2dbc.spi.Statement;
 import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,8 @@ public final class MockStatement implements Statement {
     private boolean addCalled = false;
 
     private Map<Object, Object> current;
+
+    private String[] generatedValuesColumns;
 
     private MockStatement(Flux<Result> results) {
         this.results = Assert.requireNonNull(results, "results must not be null");
@@ -97,16 +100,28 @@ public final class MockStatement implements Statement {
         return this.bindings;
     }
 
+    public String[] getGeneratedValuesColumns() {
+        return this.generatedValuesColumns;
+    }
+
     public boolean isAddCalled() {
         return this.addCalled;
     }
 
     @Override
+    public Statement returnGeneratedValues(String... columns) {
+        this.generatedValuesColumns = columns;
+        return this;
+    }
+
+    @Override
     public String toString() {
         return "MockStatement{" +
-            "bindings=" + this.bindings +
-            ", results=" + this.results +
-            ", current=" + this.current +
+            "bindings=" + bindings +
+            ", results=" + results +
+            ", addCalled=" + addCalled +
+            ", current=" + current +
+            ", generatedValuesColumns=" + Arrays.toString(generatedValuesColumns) +
             '}';
     }
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Statement.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Statement.java
@@ -165,4 +165,14 @@ public interface Statement {
      */
     Publisher<? extends Result> execute();
 
+    /**
+     * Configures {@link Statement} to return the generated values from any rows created by this {@link Statement} in the {@link Result} returned from {@link #execute()}.  If no columns are specified,
+     * implementations are free to choose which columns will be returned.  If called multiple times, only the columns requested in the final invocation will be returned.
+     *
+     * @param columns the names of the columns to return
+     * @return this {@code Statement}
+     * @throws IllegalArgumentException if {@code columns}, or any item in {@code columns} is {@code null}
+     */
+    Statement returnGeneratedValues(String... columns);
+
 }


### PR DESCRIPTION
In a previous change, the ability to return the values of generated columns was removed as unnecessary.  Feedback from that removal indicated that it was useful.  This change adds a `returnGeneratedValues()` method that indicates that a statement should return the values from a collection of generated columns.

[#25]