### PR TITLE
Extend ColumnMetadata

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/compliance.adoc
+++ b/r2dbc-spec/src/main/asciidoc/compliance.adoc
@@ -27,7 +27,7 @@ A driver may provide support for features which are not implemented by the under
 
 The following guidelines apply to R2DBC compliance:
 
-* An R2DBC API should implement SQL support as its primary interface. R2DBC does not rely upon, nor it presumes a specific SQL version. SQL and aspects of statements can be entirely handled in the data source or as part of the driver.
+* An R2DBC API should implement SQL support as its primary interface. R2DBC does not rely upon, nor does it presume a specific SQL version. SQL and aspects of statements can be entirely handled in the data source or as part of the driver.
 
 * The specification consists of this specification document and specifications documented in each interface's Javadoc.
 
@@ -35,7 +35,7 @@ The following guidelines apply to R2DBC compliance:
 
 * Drivers must support transactions.
 
-* Drivers must support named and indexed access to column and parameter references.
+* Drivers must support native and indexed access to column and parameter references.
 
 * Index references to columns and parameters are zero-based. The first index begins with `0`.
 

--- a/r2dbc-spec/src/main/asciidoc/compliance.adoc
+++ b/r2dbc-spec/src/main/asciidoc/compliance.adoc
@@ -1,0 +1,64 @@
+[[compliance]]
+= Compliance
+
+This chapter identifies the required features of a D2DBC driver implementation to claim compliance.
+Any not identified features are considered optional.
+
+[[compliance.definitions]]
+== Definitions
+
+To avoid ambiguity, we will use the following terms in the compliance section and across this specification:
+
+* _R2DBC driver implementation_ (short: driver): A driver implementing the R2DBC SPI.
+A driver may provide support for features which are not implemented by the underlying database or expose functionality that is not declared by the R2DBC SPI (_"Extension"_).
+
+* _Supported feature_: A feature for which the R2DBC API implementation supports standard syntax and semantics.
+
+* _Partially supported feature_: A feature for which some methods are implemented via standard syntax and semantics and some required methods are not implemented, typically covered by `default` interface methods.
+
+* _Extension_: A feature that is not covered by R2DBC or a non-standard implementation of a feature that is covered.
+
+* _Fully implemented_: Term to express that an interface has all its methods implemented to support the semantics defined in this specification.
+
+* _Must implement_: Term to express that an interface must be implemented although some methods on the interface are considered optional. Methods that are not implemented rely on the `default` implementation.
+
+[[compliance.guidelines]]
+== Guidelines and Requirements
+
+The following guidelines apply to R2DBC compliance:
+
+* An R2DBC API should implement SQL support as its primary interface. R2DBC does not rely upon, nor it presumes a specific SQL version. SQL and aspects of statements can be entirely handled in the data source or as part of the driver.
+
+* The specification consists of this specification document and specifications documented in each interface's Javadoc.
+
+* Drivers must support bind parameter markers.
+
+* Drivers must support transactions.
+
+* Drivers must support named and indexed access to column and parameter references.
+
+* Index references to columns and parameters are zero-based. The first index begins with `0`.
+
+== R2DBC API Compliance
+
+A driver that is compliant with the R2DBC specification must do the following:
+
+* Adhere to the guidelines and requirements above.
+* Support `ConnectionFactory` discovery through Java Service Loader of `ConnectionFactoryProvider`.
+* Implement a non-blocking I/O layer.
+* Fully implement the following interfaces:
+  ** `io.r2dbc.spi.ConnectionFactory`
+  ** `io.r2dbc.spi.ConnectionFactoryMetadata`
+  ** `io.r2dbc.spi.ConnectionFactoryProvider`
+  ** `io.r2dbc.spi.Result`
+  ** `io.r2dbc.spi.Row`
+  ** `io.r2dbc.spi.RowMetadata`
+  ** `io.r2dbc.spi.Batch`
+* Must implement `io.r2dbc.spi.Statement` interface with the exception of the following optional methods:
+  ** `returnGeneratedValues(…)`: Calling this method should be a no-op for drivers not supporting key generation.
+* Must implement `io.r2dbc.spi.ColumnMetadata` interface with the exception of the following optional methods:
+  ** `getPrecision()`
+  ** `getScale()`
+  ** `getNullability()`
+  ** `getJavaType()`
+  ** `getNativeTypeMetadata()`

--- a/r2dbc-spec/src/main/asciidoc/index.adoc
+++ b/r2dbc-spec/src/main/asciidoc/index.adoc
@@ -19,3 +19,7 @@ include::preface.adoc[]
 include::introduction.adoc[leveloffset=+1]
 
 include::goals.adoc[leveloffset=+1]
+
+include::compliance.adoc[leveloffset=+1]
+
+include::row-metadata.adoc[leveloffset=+1]

--- a/r2dbc-spec/src/main/asciidoc/row-metadata.adoc
+++ b/r2dbc-spec/src/main/asciidoc/row-metadata.adoc
@@ -1,0 +1,72 @@
+[[rowmetadata]]
+= Column and Row Metadata
+
+The `RowMetadata` interface is implemented by R2DBC drivers to provide information about tabular results.
+It is used primarily by libraries and applications to determine the properties of a row and its columns.
+
+In cases where the result properties of a SQL statement are unknown until execution, the `RowMetadata` can be used to determine the actual properties of a row.
+
+`RowMetadata` exposes `ColumnMetadata` for each column in the result.
+Drivers should provide `ColumnMetadata` on a best-effort basis.
+Column metadata is typically a by-product of statement execution.
+The amount of available information is vendor-dependent.
+Metadata retrieval can require additional lookups (internal query execution) to provide a complete metadata descriptor.
+Issuing queries during result processing conflicts with the streaming nature of R2DBC and so `ColumnMetadata` declares two sets of methods: Methods that must be implemented and methods that can optionally be implemented by drivers.
+
+== Obtaining a `RowMetadata` Object
+
+A `RowMetadata` object is created during tabular results consumption through `Result.map(…)`.
+It is created for each row. The following example illustrates retrieval and usage using an anonymous inner class:
+
+.Using `RowMetadata` and retieving `ColumnMetadata`
+====
+[source,java]
+----
+// result is a Result object
+result.map(new BiFunction<Row, RowMetadata, Object>() {
+
+    @Override
+    public Object apply(Row row, RowMetadata rowMetadata) {
+        ColumnMetadata my_column = rowMetadata.getColumnMetadata("my_column");
+        ColumnMetadata.Nullability nullability = my_column.getNullability();
+        // …
+    }
+})
+----
+====
+
+[[columnmetadata]]
+== Retrieving `ColumnMetadata`
+
+`RowMetadata` methods are used to retrieve metadata for a single or all columns.
+
+* `getColumnMetadata(…)` returns the `ColumnMetadata` by using a column identifier. The identifier is either a zero-based index or the column name, see <<compliance.guidelines>>.
+* `getColumnMetadatas()` returns an unmodifiable collection of `ColumnMetadata` objects.
+
+== Retrieving General Information for a Column
+
+`ColumnMetadata` declares methods to access column metadata on a best-effort basis.
+Column metadata that is available as a by-product of statement execution must be made available through `ColumnMetadata`.
+Metadata exposure requiring interaction with the database (e.g. issuing queries to information schema entities to resolve type properties) should not be exposed as methods on `ColumnMetadata` are expected to be non-blocking.
+
+NOTE: Implementation note: Drivers can use metadata from a static mapping or obtain metadata indexes on connection creation.
+
+The following example illustrates how to consume `ColumnMetadata` using lambdas:
+
+.Retrieving `ColumnMetadata` information
+====
+[source,java]
+----
+// row is a RowMetadata object
+row.getColumnMetadatas().forEach(columnMetadata -> {
+
+    String name = columnMetadata.getName();
+    Integer precision = columnMetadata.getPrecision();
+    Integer scale = columnMetadata.getScale();
+});
+----
+====
+
+See the API specification for more details.
+
+

--- a/r2dbc-spec/src/main/asciidoc/row-metadata.adoc
+++ b/r2dbc-spec/src/main/asciidoc/row-metadata.adoc
@@ -68,5 +68,3 @@ row.getColumnMetadatas().forEach(columnMetadata -> {
 ====
 
 See the API specification for more details.
-
-

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockColumnMetadata.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockColumnMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,13 @@
 package io.r2dbc.spi.test;
 
 import io.r2dbc.spi.ColumnMetadata;
+import io.r2dbc.spi.Nullability;
 
 public final class MockColumnMetadata implements ColumnMetadata {
 
     public static final String EMPTY_NAME = "empty-name";
 
-    public static final Nullability EMPTY_NULLABILITY = Nullability.Unknown;
+    public static final Nullability EMPTY_NULLABILITY = Nullability.UNKNOWN;
 
     private final String name;
 

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockColumnMetadata.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockColumnMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,24 +18,31 @@ package io.r2dbc.spi.test;
 
 import io.r2dbc.spi.ColumnMetadata;
 
-import java.util.Optional;
-
 public final class MockColumnMetadata implements ColumnMetadata {
 
     public static final String EMPTY_NAME = "empty-name";
 
-    public static final Integer EMPTY_TYPE = Integer.MAX_VALUE;
+    public static final Nullability EMPTY_NULLABILITY = Nullability.Unknown;
 
     private final String name;
 
     private final Integer precision;
 
-    private final Integer type;
+    private final Integer scale;
 
-    private MockColumnMetadata(String name, @Nullable Integer precision, Integer type) {
+    private final Nullability nullability;
+
+    private final Class<?> type;
+
+    private final Object nativeMetadata;
+
+    private MockColumnMetadata(String name, @Nullable Integer precision, @Nullable Integer scale, Nullability nullability, @Nullable Class<?> type, @Nullable Object nativeMetadata) {
         this.name = Assert.requireNonNull(name, "name must not be null");
         this.precision = precision;
-        this.type = Assert.requireNonNull(type, "type must not be null");
+        this.scale = scale;
+        this.nullability = Assert.requireNonNull(nullability, "nullability must not be null");
+        this.type = type;
+        this.nativeMetadata = nativeMetadata;
     }
 
     public static Builder builder() {
@@ -45,7 +52,7 @@ public final class MockColumnMetadata implements ColumnMetadata {
     public static MockColumnMetadata empty() {
         return builder()
             .name(EMPTY_NAME)
-            .type(EMPTY_TYPE)
+            .nullability(EMPTY_NULLABILITY)
             .build();
     }
 
@@ -55,13 +62,28 @@ public final class MockColumnMetadata implements ColumnMetadata {
     }
 
     @Override
-    public Optional<Integer> getPrecision() {
-        return Optional.ofNullable(this.precision);
+    public Integer getPrecision() {
+        return this.precision;
     }
 
     @Override
-    public Integer getType() {
+    public Integer getScale() {
+        return this.scale;
+    }
+
+    @Override
+    public Nullability getNullability() {
+        return this.nullability;
+    }
+
+    @Override
+    public Class<?> getJavaType() {
         return this.type;
+    }
+
+    @Override
+    public Object getNativeTypeMetadata() {
+        return this.nativeMetadata;
     }
 
     @Override
@@ -69,7 +91,10 @@ public final class MockColumnMetadata implements ColumnMetadata {
         return "MockColumnMetadata{" +
             "name='" + this.name + '\'' +
             ", precision=" + this.precision +
+            ", scale=" + this.scale +
+            ", nullability=" + this.nullability +
             ", type=" + this.type +
+            ", nativeMetadata=" + this.nativeMetadata +
             '}';
     }
 
@@ -79,13 +104,19 @@ public final class MockColumnMetadata implements ColumnMetadata {
 
         private Integer precision;
 
-        private Integer type;
+        private Integer scale;
+
+        private Nullability nullability;
+
+        private Class<?> type;
+
+        private Object nativeMetadata;
 
         private Builder() {
         }
 
         public MockColumnMetadata build() {
-            return new MockColumnMetadata(this.name, this.precision, this.type);
+            return new MockColumnMetadata(this.name, this.precision, this.scale, this.nullability, this.type, this.nativeMetadata);
         }
 
         public Builder name(String name) {
@@ -98,20 +129,37 @@ public final class MockColumnMetadata implements ColumnMetadata {
             return this;
         }
 
+        public Builder scale(Integer precision) {
+            this.scale = Assert.requireNonNull(precision, "scale must not be null");
+            return this;
+        }
+
+        public Builder nullability(Nullability nullability) {
+            this.nullability = Assert.requireNonNull(nullability, "nullability must not be null");
+            return this;
+        }
+
+        public Builder type(Class<?> type) {
+            this.type = Assert.requireNonNull(type, "type must not be null");
+            return this;
+        }
+
+        public Builder nativeMetadata(Object nativeMetadata) {
+            this.nativeMetadata = Assert.requireNonNull(nativeMetadata, "nativeMetadata must not be null");
+            return this;
+        }
+
         @Override
         public String toString() {
             return "Builder{" +
                 "name='" + this.name + '\'' +
                 ", precision=" + this.precision +
+                ", scale=" + this.scale +
+                ", nullability=" + this.nullability +
                 ", type=" + this.type +
+                ", nativeMetadata=" + this.nativeMetadata +
                 '}';
         }
-
-        public Builder type(Integer type) {
-            this.type = Assert.requireNonNull(type, "type must not be null");
-            return this;
-        }
-
     }
 
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ColumnMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ColumnMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ public interface ColumnMetadata {
     String getName();
 
     /**
-     * Return the precision of the column.
+     * Returns the precision of the column.
      * <p>
      * For numeric data, this is the maximum precision.
      * For character data, this is the length in characters.
@@ -53,7 +53,7 @@ public interface ColumnMetadata {
      * Returns the scale of the column.
      * <p>
      * This is the number of digits to right of the decimal point.
-     * Returns {@code null} for data types where the scale is not applicable  or if the precision cannot be provided.
+     * Returns {@code null} for data types where the scale is not applicable or if the precision cannot be provided.
      * <p>
      * <strong>Implementation notes</strong>
      * Implementation of this method is optional. The default implementation returns {@code null}.
@@ -69,13 +69,13 @@ public interface ColumnMetadata {
      * Returns the nullability of column values.
      * <p>
      * <strong>Implementation notes</strong>
-     * Implementation of this method is optional. The default implementation returns {@link Nullability#Unknown}.
+     * Implementation of this method is optional. The default implementation returns {@link Nullability#UNKNOWN}.
      *
      * @return the nullability of column values.
      * @see Nullability
      */
     default Nullability getNullability() {
-        return Nullability.Unknown;
+        return Nullability.UNKNOWN;
     }
 
     /**
@@ -105,27 +105,6 @@ public interface ColumnMetadata {
     @Nullable
     default Object getNativeTypeMetadata() {
         return null;
-    }
-
-    /**
-     * Constants indicating nullability of column values.
-     */
-    enum Nullability {
-
-        /**
-         * Indicating that a column does allow {@code NULL} values.
-         */
-        Nullable,
-
-        /**
-         * Indicating that a column does not allow {@code NULL} values.
-         */
-        NonNull,
-
-        /**
-         * Indicating that the nullability of a column's values is unknown.
-         */
-        Unknown
     }
 
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Nullability.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Nullability.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+/**
+ * Constants indicating nullability of column values.
+ */
+public enum Nullability {
+
+    /**
+     * Indicating that a column does allow {@code NULL} values.
+     */
+    NULLABLE,
+
+    /**
+     * Indicating that a column does not allow {@code NULL} values.
+     */
+    NON_NULL,
+
+    /**
+     * Indicating that the nullability of a column's values is unknown.
+     */
+    UNKNOWN
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.r2dbc.spi;
 
+import java.util.NoSuchElementException;
+
 /**
  * Represents the metadata for a row of the results returned from a query.
  */
@@ -26,7 +28,9 @@ public interface RowMetadata {
      *
      * @param identifier the identifier of the column
      * @return the {@link ColumnMetadata} for one column in this row
-     * @throws IllegalArgumentException if {@code identifier} is {@code null}
+     * @throws IllegalArgumentException       if {@code identifier} is {@code null} or not supported
+     * @throws NoSuchElementException         if there is no column with the name {@code identifier}
+     * @throws ArrayIndexOutOfBoundsException if the {@code identifier} is a {@link Integer index} and it is less than zero or greater than the number of available columns.
      */
     ColumnMetadata getColumnMetadata(Object identifier);
 


### PR DESCRIPTION
`ColumnMetadata` now exposes additional metadata information on a best-effort basis. Drivers are free to provide metadata if it is available as part of a result response or statically available. Drivers also can decide which methods to implement and they can expose a native metadata object if they can expose additional metadata.

Document behavior for absent columns and invalid identifiers

Document column metadata and general guidelines for R2DBC implementors

---

This change requires downstream changes in driver implementations.

Resolves #22 

