### PR TITLE
Add diagnostic information to ConnectionFactories

### DIFF
--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactories.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactories.java
@@ -60,7 +60,20 @@ public final class ConnectionFactories {
         ConnectionFactory connectionFactory = find(connectionFactoryOptions);
 
         if (connectionFactory == null) {
-            throw new IllegalStateException(String.format("Unable to create a ConnectionFactory for '%s'", connectionFactoryOptions));
+            StringBuilder availableDrivers = new StringBuilder();
+
+            String separator = "";
+            for (ConnectionFactoryProvider provider : loadProviders()) {
+                availableDrivers.append(separator);
+                availableDrivers.append(provider.getDriver());
+                separator = ", ";
+            }
+
+            if (availableDrivers.length() < 1) {
+                availableDrivers.append("None");
+            }
+
+            throw new IllegalStateException(String.format("Unable to create a ConnectionFactory for '%s'. Available drivers: [ %s ]", connectionFactoryOptions, availableDrivers));
         }
 
         return connectionFactory;

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryProvider.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryProvider.java
@@ -40,4 +40,12 @@ public interface ConnectionFactoryProvider {
      */
     boolean supports(ConnectionFactoryOptions connectionFactoryOptions);
 
+    /**
+     * Returns the driver identifier used by the driver.
+     * The identifier for drivers would be the value applicable to {@link ConnectionFactoryOptions#DRIVER}
+     *
+     * @return The driver identifier used by the driver
+     */
+    String getDriver();
+
 }


### PR DESCRIPTION
Introduced a new method 'getDriver()' in ConnectionFactoryProvider
where implementations would expose the name of the driver used.

Failing to find a ConnectionFactory will provide information about
available drivers.

[resolves #49]

When a connection factory for a given driver is not found the error message would now print a message as follows;
```
java.lang.IllegalStateException: Unable to create a ConnectionFactory for 'ConnectionFactoryOptions{options={url=mem:ZWvhOYa6, user=4H1W6fyIPOjua63l, driver=h4, password=REDACTED}}'. Available drivers: [ h2, h3 ]
```
where `h2` and `h3` are currently available driver and the requested factory is for a driver `h4` 

If no driver was available at all, then a the the error message would be as follows;
```
java.lang.IllegalStateException: Unable to create a ConnectionFactory for 'ConnectionFactoryOptions{options={url=mem:EvBcepdn, user=R9DZzRoutXSYtjYv, driver=h2, password=REDACTED}}'. Available drivers: [ None ]
```