### PR TITLE
URL Cleanup

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@
         xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-                http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -107,7 +107,7 @@
                     <version>3.0.1</version>
                     <configuration>
                         <links>
-                            <link>http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/</link>
+                            <link>https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/</link>
                         </links>
                     </configuration>
                     <executions>

--- a/r2dbc-spec/pom.xml
+++ b/r2dbc-spec/pom.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@
         xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-                http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/r2dbc-spec/src/main/asciidoc/data-types.adoc
+++ b/r2dbc-spec/src/main/asciidoc/data-types.adoc
@@ -1,0 +1,249 @@
+[[datatypes]]
+= Data Types
+
+This chapter discusses the use of data types from Java and database perspectives.
+The R2DBC SPI gives applications access to data types defined as of SQL. R2DBC is not limited to SQL types, and in fact, the SPI is type-agnostic.
+
+If a data source does not support a data type described in this chapter, a driver for that data source is not required to implement the methods and interfaces associated with that data type.
+
+[[datatypes.mapping]]
+== Mapping of Data Types
+
+This section explains how SQL-specific types are mapped to Java types.
+The list is nonexhaustive and should be received as a guideline for drivers.
+R2DBC drivers should use modern types and type descriptors to exchange data for consumption by applications and consumption by the driver.
+Driver implementations should implement the following type mapping and can support additional type mappings.
+
+* <<datatypes.mapping.char,Character Types>>
+* <<datatypes.mapping.boolean,Boolean Types>>
+* <<datatypes.mapping.binary,Binary Types>>
+* <<datatypes.mapping.numeric,Numeric Types>>
+* <<datatypes.mapping.datetime,Datetime Types>>
+* <<datatypes.mapping.collection,Collection Types>>
+
+[[datatypes.mapping.char]]
+.SQL Type Mapping for Character Types
+|===
+|SQL Type|Description |Java Type
+
+| `CHARACTER` (`CHAR`)
+| Character string, fixed length.
+| `java.lang.String`
+
+| `CHARACTER VARYING` (`VARCHAR`)
+| Variable-length character string, maximum length fixed.
+| `java.lang.String`
+
+| `NATIONAL CHARACTER` (`NCHAR`)
+| `NATIONAL CHARACTER` type is the same as `CHARACTER` except that it holds standardized multibyte characters or Unicode characters.
+| `java.lang.String`
+
+| `NATIONAL CHARACTER VARYING` (`NVARCHAR`)
+| `NATIONAL CHARACTER VARYING` type is the same as `CHARACTER VARYING` except that it holds standardized multibyte characters or Unicode characters.
+| `java.lang.String`
+
+| `CHARACTER LARGE OBJECT` (`CLOB`)
+| A Character Large OBject (or `CLOB`) is a collection of character data in a DBMS, usually stored in a separate location that is referenced in the table itself.
+| `io.r2dbc.spi.Clob`
+
+| `NATIONAL CHARACTER LARGE OBJECT` (`NCLOB`)
+| `NATIONAL CHARACTER LARGE OBJECT` type is the same as `CHARACTER LARGE OBJECT` except that it holds standardized multibyte characters or Unicode characters.
+| `io.r2dbc.spi.Clob`
+
+|===
+
+[[datatypes.mapping.boolean]]
+.SQL Type Mapping for Boolean Types
+|===
+|SQL Type|Description |Java Type
+
+| `BOOLEAN`
+| Single-bit representing a boolean state.
+| `java.lang.Boolean`
+
+|===
+
+[[datatypes.mapping.binary]]
+.SQL Type Mapping for Binary Types
+|===
+|SQL Type|Description |Java Type
+
+| `BINARY`
+| Binary data, fixed length.
+| `java.nio.ByteBuffer`
+
+| `BINARY VARYING` (`VARBINARY`)
+| Variable-length character string, maximum length fixed.
+| `java.nio.ByteBuffer`
+
+| `BINARY LARGE OBJECT` (`BLOB`)
+| A Binary Large OBject (or `BLOB`) is a collection of binary data in a database management system, usually stored in a separate location that is referenced in the table itself.
+| `io.r2dbc.spi.Blob`
+
+|===
+
+[[datatypes.mapping.numeric]]
+.SQL Type Mapping for Numeric Types
+|===
+|SQL Type|Description |Java Type
+
+| `INTEGER`
+| Represents an integer. The minimum and maximum values depend on the DBMS, typically 4-byte precision.
+| `java.lang.Integer`
+
+| `SMALLINT`
+| Same as `INTEGER` type except that it might hold a smaller range of values, depending on the DBMS, typically 1- or 2-byte precision.
+| `java.lang.Short`
+
+| `BIGINT`
+| Same as `INTEGER` type except that it might hold a larger range of values, depending on the DBMS, typically 8-byte precision.
+| `java.lang.Long`
+
+| `DECIMAL(p, s)`, `NUMERIC(p, s)`
+| Fixed precision and scale numbers with precision `p`, scale `s`. A decimal number, that is a number that can have a decimal point in it. The size argument has two parts: precision and scale.
+| `java.math.BigDecimal`
+
+| `FLOAT(p)`
+| Represents an approximate numerical with mantissa precision `p`.
+| `java.lang.Double`
+
+| `REAL`
+| Same as `FLOAT` type except that the DBMS defines the precision.
+| `java.lang.Double`
+
+|===
+
+[[datatypes.mapping.datetime]]
+.SQL Type Mapping for Datetime Types
+|===
+|SQL Type|Description |Java Type
+
+| `DATE`
+| Represents a date without specifying a time part and without timezone.
+| `java.time.LocalDate`
+
+| `TIME`
+| Represents a time without a date part and without timezone.
+| `java.time.LocalTime`
+
+| `TIMESTAMP`
+| Represents a date/time without a timezone.
+| `java.time.LocalDateTime`
+
+| `TIMESTAMP` with Timezone Offset
+| Represents a date/time with a timezone offset.
+| `java.time.OffsetDateTime`
+
+| `TIMESTAMP` with Timezone
+| Represents a date/time with a timezone.
+| `java.time.ZonedDateTime`
+
+| `INTERVAL`
+| Interval date types such as `YEAR`, `MONTH`, `DAY`, `HOUR` and similar representing a time quantity.
+| `java.time.Duration`
+
+|===
+
+[[datatypes.mapping.collection]]
+.SQL Type Mapping for Collection Types
+|===
+|SQL Type|Description |Java Type
+
+| `COLLECTION`
+( `ARRAY`, `MULTISET` )
+| Represents a collection of items with a base type.
+| Array-Variant of the corresponding Java type (e.g. `Integer[]` for `INTEGER ARRAY`)
+
+|===
+
+Vendor-specific types (such as spatial data types, structured JSON/XML data, user-defined types) are subject to vendor-specific mapping.
+
+[[datatypes.mapping.advanced]]
+== Mapping of Advanced Data Types
+
+The R2DBC API declares default mappings for advanced data types. The following list describes data types and the interfaces to which they map:
+
+* `BLOB` — the `Blob` interface
+* `CLOB` — the `Clob` interface
+
+[[datatypes.lob]]
+=== `Blob` and `Clob` Objects
+
+An implementation of a `Blob` or `Clob` object may either be locator based or fully materialize the object in the driver.
+Drivers should prefer locator-based `Blob` and `Clob` interface implementations to reduce pressure on the client when materializing results.
+
+For implementations that fully materialize the Large Objects (LOB), the `Blob` and `Clob` objects remain valid until the LOB is consumed or the `discard()` method is called.
+
+Portable applications should not depend upon the LOB validity past the end of a transaction.
+
+[[datatypes.lob.create]]
+=== Creating `Blob` and `Clob` Objects
+
+Large Objects are backed by a `Publisher` emitting the component type of the large object such as `ByteBuffer` for `BLOB` and `CharSequence` (or a subtype of it) for `CLOB`.
+
+Both interfaces provide factory methods to create implementations to be used with `Statement`. The following example explains how to create a `Clob` object:
+
+.Creating and using a `Clob` object
+====
+[source,java]
+----
+// charstream is a Publisher<String> object
+  // statement is a Statement object
+Clob clob = Clob.from(charstream)
+statement.bind("text", clob);
+----
+====
+
+[[datatypes.lob.retrieve]]
+=== Retrieving `Blob` and `Clob` Objects from a `Row`
+
+The binary large object (`BLOB`) and character large object (`CLOB`) data types are treated similarly to primitive built-in types. Values of these types can be retrieved by calling the `get(…)` methods on the `Row` interface.
+
+.Retrieving a `Clob` object
+====
+[source,java]
+----
+// result is a Row object
+Publisher<Clob> clob = result.map((row, rowMetadata) -> row.get("clob", Clob.class));
+----
+====
+
+The `Clob` interface contains methods for returning the content and for releasing resources associated with the `Clob` object instance.
+The API documentation provides more details.
+
+[[datatypes.lob.data]]
+=== Accessing `Blob` and `Clob` Data
+
+The `Blob` and `Clob` interfaces declare methods to consume the content of each type.
+Content streams follow Reactive Streams specifications and reflect the stream nature of large objects hence `Blob` and `Clob` objects can be consumed only once.
+Large object data consumption can be canceled by either calling the `discard()` method if the content stream was not consumed at all. Alternatively, if the content stream was consumed, a `Subscription` cancellation releases resources associated with the large object.
+
+The following example explains how to consume `Clob` contents:
+
+.Creating and using a `Clob` object
+====
+[source,java]
+----
+// clob is a Clob object
+Publisher<CharSequence> charstream = clob.stream();
+----
+====
+
+[[datatypes.lob.releasing]]
+=== Releasing `Blob` and `Clob`
+
+`Blob` and `Clob` objects remain valid for at least the duration of the transaction in which they are created.
+This could potentially result in an application running out of resources during a long-running transaction.
+Applications may release `Blob` and `Clob` by either consuming the content stream or disposing of resources by calling the `discard()` method.
+
+The following example shows how to free `Clob` resources without consuming it:
+
+.Freeing `Clob` object resources
+====
+[source,java]
+----
+// clob is a Clob object
+Publisher<Void> charstream = clob.discard();
+charstream.subscribe(…);
+----
+====

--- a/r2dbc-spec/src/main/asciidoc/index.adoc
+++ b/r2dbc-spec/src/main/asciidoc/index.adoc
@@ -23,3 +23,5 @@ include::goals.adoc[leveloffset=+1]
 include::compliance.adoc[leveloffset=+1]
 
 include::row-metadata.adoc[leveloffset=+1]
+
+include::data-types.adoc[leveloffset=+1]

--- a/r2dbc-spi-test/pom.xml
+++ b/r2dbc-spi-test/pom.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@
         xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-                http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/r2dbc-spi/pom.xml
+++ b/r2dbc-spi/pom.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@
         xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-                http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Blob.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Blob.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.nio.ByteBuffer;
+
+public interface Blob {
+
+    /**
+     * Creates a new {@link Blob} wrapper that is backed by a {@link Publisher} of {@link ByteBuffer}.
+     * The wrapper subscribes and cancels the subscription immediately on {@link #discard()}.
+     *
+     * @param p the backing {@link Publisher} of {@link ByteBuffer}.
+     * @return the {@link Blob} wrapper
+     */
+    static Blob from(Publisher<ByteBuffer> p) {
+        Assert.requireNonNull(p, "Publisher must not be null");
+
+        DefaultLob<ByteBuffer> lob = new DefaultLob<>(p);
+
+        return new Blob() {
+
+            @Override
+            public Publisher<ByteBuffer> stream() {
+                return lob.stream();
+            }
+
+            @Override
+            public Publisher<Void> discard() {
+                return lob.discard();
+            }
+        };
+    }
+
+    /**
+     * Returns the content stream as a {@link Publisher} emitting {@link ByteBuffer} chunks.
+     * <p>
+     * The content stream can be consumed ("subscribed to") only once. Subsequent consumptions result in a {@link IllegalStateException}.
+     * <p>
+     * Once {@link Publisher#subscribe(Subscriber) subscribed}, {@link Subscription#cancel() canceling} the subscription releases resources associated with this {@link Blob}.
+     *
+     * @return a {@link Publisher} emitting {@link ByteBuffer} chunks.
+     */
+    Publisher<ByteBuffer> stream();
+
+    /**
+     * Release any resources held by the {@link Clob} when not subscribing to the {@link #stream() stream content}.
+     *
+     * @return a {@link Publisher} that termination is complete
+     */
+    Publisher<Void> discard();
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Clob.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Clob.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Represents a handle to a large character object.
+ */
+public interface Clob {
+
+    /**
+     * Creates a new {@link Clob} wrapper that is backed by a {@link Publisher} of {@link CharSequence} or its subtypes.
+     * The wrapper subscribes and cancels the subscription immediately on {@link #discard()}.
+     *
+     * @param p the backing {@link Publisher} of {@link CharSequence}.
+     * @return the {@link Clob} wrapper
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static Clob from(Publisher<? extends CharSequence> p) {
+        Assert.requireNonNull(p, "Publisher must not be null");
+
+        DefaultLob<CharSequence> lob = new DefaultLob(p);
+
+        return new Clob() {
+
+            @Override
+            public Publisher<CharSequence> stream() {
+                return lob.stream();
+            }
+
+            @Override
+            public Publisher<Void> discard() {
+                return lob.discard();
+            }
+        };
+    }
+
+    /**
+     * Returns the content stream as a {@link Publisher} emitting {@link CharSequence} chunks.
+     * <p>
+     * The content stream can be consumed ("subscribed to") only once. Subsequent consumptions result in a {@link IllegalStateException}.
+     * <p>
+     * Once {@link Publisher#subscribe(Subscriber) subscribed}, {@link Subscription#cancel() canceling} the subscription releases resources associated with this {@link Clob}.
+     *
+     * @return a {@link Publisher} emitting {@link CharSequence} chunks.
+     */
+    Publisher<CharSequence> stream();
+
+    /**
+     * Release any resources held by the {@link Clob} when not subscribing to the {@link #stream() stream content}.
+     *
+     * @return a {@link Publisher} that termination is complete
+     */
+    Publisher<Void> discard();
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/DefaultLob.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/DefaultLob.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+/**
+ * Abstract implementation for large object types.
+ */
+class DefaultLob<T> {
+
+    @SuppressWarnings("unchecked")
+    private static final AtomicIntegerFieldUpdater<DefaultLob<?>> ATOMIC_DISCARD = (AtomicIntegerFieldUpdater) AtomicIntegerFieldUpdater.newUpdater(DefaultLob.class, "discarded");
+
+    @SuppressWarnings("unchecked")
+    private static final AtomicIntegerFieldUpdater<DefaultLob<?>> ATOMIC_CONSUMED = (AtomicIntegerFieldUpdater) AtomicIntegerFieldUpdater.newUpdater(DefaultLob.class, "consumed");
+
+    private static final int NOT_DISCARDED = 0;
+
+    private static final int DISCARDED = 1;
+
+    private static final int NOT_CONSUMED = 0;
+
+    private static final int CONSUMED = 1;
+
+    private final Publisher<T> p;
+
+    private volatile int discarded = NOT_DISCARDED;
+
+    private volatile int consumed = NOT_CONSUMED;
+
+    /**
+     * Creates a new {@link DefaultLob} instance.
+     *
+     * @param p
+     */
+    DefaultLob(Publisher<T> p) {
+        this.p = p;
+    }
+
+    /**
+     * Returns the content stream.
+     *
+     * @return the content stream.
+     */
+    Publisher<T> stream() {
+        return subscriber -> {
+
+            if (ATOMIC_DISCARD.get(this) == DISCARDED) {
+                subscriber.onError(new IllegalStateException("Source stream was already released"));
+                return;
+            }
+
+            if (!ATOMIC_CONSUMED.compareAndSet(this, NOT_CONSUMED, CONSUMED)) {
+                subscriber.onError(new IllegalStateException("Source stream was already consumed"));
+                return;
+            }
+
+            this.p.subscribe(subscriber);
+        };
+    }
+
+    /**
+     * Discard the content stream.
+     *
+     * @return
+     */
+    Publisher<Void> discard() {
+        return outer -> {
+
+            AtomicBoolean completed = new AtomicBoolean();
+
+            if (!ATOMIC_DISCARD.compareAndSet(this, NOT_DISCARDED, DISCARDED)) {
+                outer.onError(new IllegalStateException("Source stream was already released"));
+                return;
+            }
+
+            try {
+                this.p.subscribe(new Subscriber<T>() {
+
+                    @Override
+                    public void onSubscribe(Subscription s) {
+                        s.cancel();
+                        if (completed.compareAndSet(false, true)) {
+                            outer.onComplete();
+                        }
+                    }
+
+                    @Override
+                    public void onNext(T t) {
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        if (completed.compareAndSet(false, true)) {
+                            outer.onError(new IllegalStateException("Resource release has failed", t));
+                        }
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        if (completed.compareAndSet(false, true)) {
+                            outer.onComplete();
+                        }
+                    }
+                });
+            } catch (Exception e) {
+                if (completed.compareAndSet(false, true)) {
+                    outer.onError(new IllegalStateException("Resource release has failed", e));
+                }
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 4 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 6 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/ with 1 occurrences migrated to:  
  https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/ ([https](https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 8 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences