### PR TITLE
URL Cleanup

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@
         xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-                http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -115,7 +115,7 @@
                     <version>3.0.1</version>
                     <configuration>
                         <links>
-                            <link>http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/</link>
+                            <link>https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/</link>
                         </links>
                     </configuration>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <java.version>1.8</java.version>
         <jsr305.version>3.0.2</jsr305.version>
         <junit.version>5.3.2</junit.version>
+        <assertj.version>3.11.1</assertj.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <reactor.version>Californium-SR3</reactor.version>
@@ -60,6 +61,13 @@
                 <version>${junit.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>

--- a/r2dbc-spec/pom.xml
+++ b/r2dbc-spec/pom.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@
         xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-                http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/r2dbc-spec/src/main/asciidoc/connections.adoc
+++ b/r2dbc-spec/src/main/asciidoc/connections.adoc
@@ -36,6 +36,7 @@ public interface ConnectionFactory {
     Publisher<? extends Connection> create();
 
     ConnectionFactoryMetadata getMetadata();
+
 }
 ----
 ====
@@ -48,6 +49,7 @@ It may create connections by itself, wrap a `ConnectionFactory` or apply connect
 * A `ConnectionFactory` uses deferred initialization and should initiate connection resource allocation after requesting the item (`Subscription.request(1)`).
 * Connection creation must emit exactly one `Connection` or an error signal.
 * Connection creation must be cancellable (`Subscription.cancel()`). Canceling connection creation must release ("close") the connection and all associated resources.
+* A `ConnectionFactory` should expect that it can be wrapped. Wrappers must implement the `Wrapped<ConnectionFactory>` interface and return the underlying `ConnectionFactory` when `Wrapped.unwrap()` gets called.
 
 **ConnectionFactory Metadata**
 
@@ -65,7 +67,6 @@ public interface ConnectionFactoryMetadata {
 }
 ----
 ====
-
 
 See the R2DBC SPI Specification for more details.
 
@@ -171,9 +172,12 @@ Options are identified by a literal.
 |Connection timeout to obtain a connection.
 |===
 
-The set of options is extensible.
-Drivers can declare which well-known options that they require and which they support.
-Drivers can declare which extended options they require and which they support.
+The following rules apply:
+
+* The set of options is extensible.
+* Drivers can declare which well-known options that they require and which they support.
+* Drivers can declare which extended options they require and which they support.
+* Drivers should not fail in creating a connection if more options are declared than the driver consumes as a `ConnectionFactory` should expect to be wrapped.
 
 .Configuration of `ConnectionFactoryOptions`
 ====
@@ -188,7 +192,6 @@ ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
 ====
 
 See the R2DBC SPI Specification for more details.
-
 
 == Obtaining `Connection` Objects
 

--- a/r2dbc-spec/src/main/asciidoc/connections.adoc
+++ b/r2dbc-spec/src/main/asciidoc/connections.adoc
@@ -1,0 +1,222 @@
+[[connections]]
+= Connections
+
+R2DBC uses the `Connection` interface to define a logical connection API to the underlying data source.
+A structure of a connection depends on the actual requirements of a data source and how the driver implements these.
+
+The data source can be an RDBMS, a stream-oriented data system some other source of data with a corresponding R2DBC driver.
+A single application using R2DBC API may maintain multiple connections to either a single data source or across multiple data sources.
+From a R2DBC driver perspective, a `Connection` object represents a single client session.
+It has associated state information such as user ID and what transaction semantics are in effect.
+A `Connection` object is not thread-safe in the sense that it can be shared across multiple Threads that concurrently execute statements or change its state.
+A connection object can be shared across multiple Threads that execute operations serially using appropriate synchronization mechanisms.
+
+To obtain a connection, the application may interact with either:
+
+* the `ConnectionFactories` class working with one or more `ConnectionFactoryProvider` implementations
+
+*OR*
+
+* directly a `ConnectionFactory` implementation.
+
+See <<overview.connection>> for more details.
+
+[[connections.factory]]
+== The `ConnectionFactory` Interface
+
+R2DBC drivers must implement the `ConnectionFactory` interface as a mandatory part of the SPI.
+Drivers can provide multiple `ConnectionFactory` implementations depending on the used protocol or aspects that require the use of a different `ConnectionFactory` implementation.
+
+.`ConnectionFactory` Interface
+====
+[source,java]
+----
+public interface ConnectionFactory {
+
+    Publisher<? extends Connection> create();
+
+    ConnectionFactoryMetadata getMetadata();
+}
+----
+====
+
+The following rules apply:
+
+* A `ConnectionFactory` represents a resource factory for deferred connection creation.
+It may create connections by itself, wrap a `ConnectionFactory` or apply connection pooling on top of a `ConnectionFactory`.
+* A `ConnectionFactory` provides metadata about the driver itself through `ConnectionFactoryMetadata`.
+* A `ConnectionFactory` uses deferred initialization and should initiate connection resource allocation after requesting the item (`Subscription.request(1)`).
+* Connection creation must emit exactly one `Connection` or an error signal.
+* Connection creation must be cancellable (`Subscription.cancel()`). Canceling connection creation must release ("close") the connection and all associated resources.
+
+**ConnectionFactory Metadata**
+
+ConnectionFactories are required to expose metadata to identify the driver (`ConnectionFactory`) and its capabilities.
+Metadata must not require a connection to a data source.
+
+.`ConnectionFactoryMetadata` Interface
+====
+[source,java]
+----
+public interface ConnectionFactoryMetadata {
+
+    String getName();
+
+}
+----
+====
+
+
+See the R2DBC SPI Specification for more details.
+
+[[connections.factory.discovery]]
+== `ConnectionFactory` Discovery Mechanism
+
+As part of its usage, the `ConnectionFactories` class attempts to load any R2DBC driver classes referenced
+by the `ConnectionFactoryProvider` interface listed in the Java Service Provider manifests available on the CLASSPATH.
+
+Drivers must include the file `META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider`.
+This file contains the name of the R2DBC driver's implementation (or implementations) of `io.r2dbc.spi.ConnectionFactoryProvider`.
+To ensure that drivers can be loaded using this mechanism, `io.r2dbc.spi.ConnectionFactoryProvider` implementations are required to provide a no-argument constructor.
+
+.META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider file contents
+====
+[source]
+----
+com.example.ConnectionFactoryProvider
+----
+====
+
+.`ConnectionFactoryProvider` Interface
+====
+[source,java]
+----
+public interface ConnectionFactoryProvider {
+
+    ConnectionFactory create(ConnectionFactoryOptions connectionFactoryOptions);
+
+    boolean supports(ConnectionFactoryOptions connectionFactoryOptions);
+
+}
+----
+====
+
+`ConnectionFactories` uses a `ConnectionFactoryOptions` object to lookup a matching driver using a two-step model:
+
+1. Lookup of an adequate `ConnectionFactoryProvider`.
+2. Obtain the `ConnectionFactory` from the `ConnectionFactoryProvider`.
+
+`ConnectionFactoryProvider` implementations are required to return a `boolean` indicator whether they support a specific configuration represented by `ConnectionFactoryOptions`.
+Drivers must expect any plurality of ``Option``s to be configured.
+Drivers must report that they support a configuration only if the `ConnectionFactoryProvider` can provide a `ConnectionFactory` based on the given `ConnectionFactoryOptions`.
+Drivers should gracefully fail if a `ConnectionFactory` creation through `ConnectionFactoryProvider.create(…)` is not possible.
+
+See the R2DBC SPI Specification for more details.
+
+[[connections.factory.options]]
+== The `ConnectionFactoryOptions` Class
+
+The `ConnectionFactoryOptions` class represents a configuration to request a `ConnectionFactory` from a `ConnectionFactoryProvider`.
+It represents the <<overview.connection, programmatic connection creation>> approach without using driver-specific classes.
+`ConnectionFactoryOptions` instances are created using the builder pattern and properties are configured through `Option<T>` identifiers.
+A `ConnectionFactoryOptions` is immutable once created.
+`Option` objects are reused as part of the built-in constant pool.
+Options are identified by a literal.
+
+`ConnectionFactoryOptions` defines a set of well-known options:
+
+.Well-known Options
+|===
+|Constant |Literal |Type |Description
+
+|`DRIVER`
+|`driver`
+|`java.lang.String`
+|Driver identifier.
+
+|`PROTOCOL`
+|`protocol`
+|`java.lang.String`
+|Protocol details such as the network protocol used to communicate with a server.
+
+|`USER`
+|`user`
+|`java.lang.String`
+|User account name.
+
+|`PASSWORD`
+|`password`
+|`java.lang.CharSequence`
+|User or database password.
+
+|`HOST`
+|`host`
+|`java.lang.String`
+|Database server name.
+
+|`PORT`
+|`port`
+|`java.lang.Integer`
+|Database server port number.
+
+
+|`DATABASE`
+|`database`
+|`java.lang.String`
+|Name of the particular database on a server.
+
+|`CONNECT_TIMEOUT`
+|`connectTimeout`
+|`java.time.Duration`
+|Connection timeout to obtain a connection.
+|===
+
+The set of options is extensible.
+Drivers can declare which well-known options that they require and which they support.
+Drivers can declare which extended options they require and which they support.
+
+.Configuration of `ConnectionFactoryOptions`
+====
+[source,java]
+----
+ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+    .option(ConnectionFactoryOptions.HOST, "…")
+    .option(Option.valueOf("tenant"), "…")
+    .option(Option.sensitiveValueOf("encryptionKey"), "…")
+    .build();
+----
+====
+
+See the R2DBC SPI Specification for more details.
+
+
+== Obtaining `Connection` Objects
+
+Once a `ConnectionFactory` is bootstrapped, connections are obtained from the `create()` method.
+
+.Obtaining a `Connection`
+====
+[source,java]
+----
+// factory is a ConnectionFactory object
+Publisher<? extends Connection> publisher = factory.create();
+----
+====
+
+The connection is active once it was emitted by the `Publisher` and must be released ("closed") once it is no longer in use.
+
+== Closing `Connection` Objects
+
+Calling `Connection.close()` prepares a close handle to release the connection and its associated resources.
+Connections must be closed to ensure proper resource management.
+
+.Closing a `Connection`
+====
+[source,java]
+----
+// connection is a ConnectionFactory object
+Publisher<Void> close = connection.create();
+----
+====
+
+See the R2DBC SPI Specification for more details.

--- a/r2dbc-spec/src/main/asciidoc/index.adoc
+++ b/r2dbc-spec/src/main/asciidoc/index.adoc
@@ -22,4 +22,8 @@ include::goals.adoc[leveloffset=+1]
 
 include::compliance.adoc[leveloffset=+1]
 
+include::overview.adoc[leveloffset=+1]
+
+include::connections.adoc[leveloffset=+1]
+
 include::row-metadata.adoc[leveloffset=+1]

--- a/r2dbc-spec/src/main/asciidoc/overview.adoc
+++ b/r2dbc-spec/src/main/asciidoc/overview.adoc
@@ -1,0 +1,163 @@
+[[overview]]
+= Overview
+
+R2DBC provides an API for Java programs to access one or more sources of data.
+In the majority of cases, the data source is a relational DBMS, and its data is accessed using SQL.
+R2DBC drivers are not limited to RDBMS but can be implemented on top of other data sources, including stream-oriented systems
+and object-oriented systems.
+A primary motivation for R2DBC API is providing a standard API for reactive applications to integrate with a wide variety of data sources.
+This chapter gives an overview of the API and the key concepts of the R2DBC API.
+
+[[overview.connection]]
+== Establishing a Connection
+
+R2DBC uses the `Connection` interface to define a logical connection API to the underlying data source.
+A structure of a connection depends on the actual requirements of a data source and how the driver implements these.
+
+In a typical scenario, an application using R2DBC connects to a target data source using one of two mechanisms:
+
+* `ConnectionFactories`: R2DBC SPI provides this fully implemented class. It provides `ConnectionFactory` discovery functionality for applications that want to obtain a connection without using vendor-specific API.
+When an application first attempts to connect to a data source, `ConnectionFactories` automatically loads any R2DBC driver found within the CLASSPATH using Java's `ServiceLoader` mechanism.
+See <<connections.factory.discovery, ConnectionFactory Discovery>> for details on how to implement the discovery mechanism for a particular driver.
+* `ConnectionFactory`: A `ConnectionFactory` is implemented by a driver and provides access to <<connections,`Connection`>> creation. An application that wants to configure vendor-specific aspects of a driver can use the vendor-specific `ConnectionFactory` creation mechanism to configure a `ConnectionFactory`.
+
+[[overview.connection.discovery]]
+=== Using `ConnectionFactory` Discovery
+
+As mentioned earlier, R2DBC supports the concept of discovery to find an appropriate driver for a connection request.
+Providing a `ConnectionFactory` to an application is typically a configuration-infrastructure task.
+Applications that wish to bootstrap an R2DBC client, typically handle this aspect directly in application code and so, discovery can become a task for application developers.
+
+`ConnectionFactories` provides two standard mechanisms to bootstrap a `ConnectionFactory`:
+
+* URL-based: R2DBC supports a uniform URL-based configuration scheme with a well-defined structure and well-known configuration properties. URLs are represented as Java `String` and can be passed to `ConnectionFactories` for `ConnectionFactory` lookup.
+* Programmatic: In addition to a URL-based configuration, R2DBC provides a programmatic approach so applications can supply structured configuration options to obtain a `ConnectionFactory`.
+
+R2DBC embraces in addition to the two methods mentioned above a mixed mechanism as typical configuration infrastructure mixes URL- and programmatic-based configuration of data sources for enhanced flexibility.
+A typical use case is the separation of concerns in which data source coordinates are supplied using an URL while login credentials originate from a different configuration source.
+
+[[overview.connection.url]]
+=== R2DBC Connection URL
+
+R2DBC defines a standard URL format that is an enhanced form of https://www.ietf.org/rfc/rfc3986.txt[RFC 3986 Uniform Resource Identifier (URI): Generic Syntax] and its amendments supported by Java's `java.net.URI` type.
+
+Syntax Components from https://www.ietf.org/rfc/rfc3986.txt[RFC3986]:
+
+[source,subs="none"]
+----
+&nbsp;
+      URI         = scheme ":" driver [ ":" protocol ] ":" hier-part [ "?" query ] [ "#" fragment ]
+
+      scheme      = "r2dbc" / "r2dbcs"
+
+      driver      = ALPHA *( ALPHA )
+
+      protocol    = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." / ":")
+
+      hier-part   = "//" authority path-abempty
+                  / path-absolute
+                  / path-rootless
+                  / path-empty
+
+      authority   = [ userinfo "@" ] host [ ":" port ] [ "," host [ ":" port ] ]
+
+      userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )
+
+      host        = IP-literal / IPv4address / reg-name
+
+      port        = *DIGIT
+
+      query       = *( pchar / "/" / "?" )
+
+      fragment    = *( pchar / "/" / "?" )
+
+      pct-encoded = "%" HEXDIG HEXDIG
+
+      pchar       = unreserved / pct-encoded / sub-delims / ":" / "@"
+
+      sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
+                 / "*" / "+" / "," / ";" / "="
+
+      unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
+----
+
+.R2DBC Connection URL
+====
+[source,subs="none"]
+----
+&nbsp;
+r2dbc:a-driver:pipes://localhost:3306/my_database?locale=en_US
+\___/ \______/ \___/   \____________/\__________/\___________/
+  |       |      |           |           |           |
+scheme  driver  protocol  authority    path        query
+----
+====
+
+* scheme: Identify that the URL is a valid R2DBC URL. Valid schemes are `r2dbc` and `r2dbcs` (configure SSL usage).
+* driver: Identifier for a driver. R2DBC has no authority over driver identifiers.
+* protocol: Used as optional protocol information to configure a driver-specific protocol. Protocols can be organized hierarchically and are separated by a colon (":").
+* authority: Contains endpoint and authorization. The authority may contain a single host or a collection of hostnames/hostname and port tuples by separating these with a comma (",").
+* path (Optional): Used as an initial schema/database name.
+* query (Optional): Used to pass additional configuration options in the form of `String` key-value pairs using the key name as option name.
+* fragment: Unused ("Reserved for future use")
+
+`ConnectionFactoryOptions.parse(String)` parses a R2DBC URL into `ConnectionFactoryOptions` using Standard- and optional Extended options.
+A R2DBC Connection URL is parsed into the following options (using `ConnectionFactoryOptions` constants):
+
+Example URL
+.R2DBC Connection URL
+====
+[source]
+----
+r2dbc:a-driver:pipes://hello:world@localhost:3306/my_database?locale=en_US
+----
+====
+
+.Parsed Standard Options
+|===
+|Option |URL Part |Value as per Example
+
+|`ConnectionFactoryOptions.DRIVER`
+|`driver`
+|`a-driver`
+
+|`ConnectionFactoryOptions.PROTOCOL`
+|`protocol`
+|`pipes`
+
+|`ConnectionFactoryOptions.USER`
+|User-part of `authority`
+|`hello`
+
+|`ConnectionFactoryOptions.PASSWORD`
+|Password-part of `authority`
+|`world`
+
+|`ConnectionFactoryOptions.HOST`
+|Host-part of `authority`
+|`localhost`
+
+|`ConnectionFactoryOptions.PORT`
+|Port-part of `authority`
+|`3306`
+
+|`ConnectionFactoryOptions.DATABASE`
+|`path` without leading `/`
+|`my_database`
+|===
+
+.Parsed Extended Options
+|===
+|Option |URL Part |Value as per Example
+
+|`locale`
+|key-value tuple from `query`
+|`en_US`
+|===
+
+NOTE: R2DBC defines well-known standard options that are available as runtime constants through `ConnectionFactories`. Additional options identifiers are created through `Option.valueOf(…)`.
+
+[[overview.connection.usage]]
+=== Executing SQL and Retrieving Results
+
+TBD.

--- a/r2dbc-spi-test/pom.xml
+++ b/r2dbc-spi-test/pom.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@
         xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-                http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/r2dbc-spi/pom.xml
+++ b/r2dbc-spi/pom.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@
         xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-                http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/r2dbc-spi/pom.xml
+++ b/r2dbc-spi/pom.xml
@@ -51,6 +51,24 @@
             <artifactId>jsr305</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactories.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactories.java
@@ -51,7 +51,7 @@ public final class ConnectionFactories {
     /**
      * Returns a {@link ConnectionFactory} from an available implementation, created from a R2DBC Connection URL.
      * R2DBC URL format is:
-     * {@code r2dbc:driver[:protocol[:subprotocols]}://[user:password@]host[:port][/path][?option=value]}.
+     * {@code r2dbc:driver[:protocol]}://[user:password@]host[:port][/path][?option=value]}.
      *
      * @param url the R2DBC connection url
      * @return the created {@link ConnectionFactory}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactories.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactories.java
@@ -49,6 +49,20 @@ public final class ConnectionFactories {
     }
 
     /**
+     * Returns a {@link ConnectionFactory} from an available implementation, created from a R2DBC Connection URL.
+     * R2DBC URL format is:
+     * {@code r2dbc:driver[:protocol[:subprotocols]}://[user:password@]host[:port][/path][?option=value]}.
+     *
+     * @param url the R2DBC connection url
+     * @return the created {@link ConnectionFactory}
+     * @throws IllegalArgumentException if {@code url} is {@code null}
+     * @throws IllegalStateException    if no available implementation can create a {@link ConnectionFactory}
+     */
+    public static ConnectionFactory get(String url) {
+        return get(ConnectionFactoryOptions.parse(Assert.requireNonNull(url, "R2DBC Connection URL must not be null")));
+    }
+
+    /**
      * Returns a {@link ConnectionFactory} from an available implementation, created from a collection of {@link ConnectionFactoryOptions}.
      *
      * @param connectionFactoryOptions a collection of {@link ConnectionFactoryOptions}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * A holder for configuration options related to {@link ConnectionFactory}s.
@@ -97,6 +98,15 @@ public final class ConnectionFactoryOptions {
      */
     public static ConnectionFactoryOptions parse(CharSequence url) {
         return ConnectionUrlParser.parseQuery(Assert.requireNonNull(url, "R2DBC Connection URL must not be null"));
+    }
+
+    /**
+     * Returns a new {@link Builder} initialized with this {@link ConnectionFactoryOptions}.
+     *
+     * @return a new {@link Builder}
+     */
+    public Builder mutate() {
+        return new Builder().from(this);
     }
 
     /**
@@ -195,9 +205,27 @@ public final class ConnectionFactoryOptions {
          * @throws IllegalArgumentException if {@code connectionFactoryOptions} is {@code null}
          */
         public Builder from(ConnectionFactoryOptions connectionFactoryOptions) {
-            Assert.requireNonNull(connectionFactoryOptions, "connectionFactoryOptions must not be null");
+            return from(connectionFactoryOptions, it -> true);
+        }
 
-            this.options.putAll(connectionFactoryOptions.options);
+        /**
+         * Populates the builder with the existing values from a configured {@link ConnectionFactoryOptions} allowing to {@link Predicate filter} which values to include.
+         *
+         * @param connectionFactoryOptions a configured {@link ConnectionFactoryOptions}
+         * @param filter                   a {@link Predicate filter function} to include/exclude existing {@link Option}s.
+         * @return this {@link Builder}
+         * @throws IllegalArgumentException if {@code connectionFactoryOptions} or {@code filter} is {@code null}
+         */
+        public Builder from(ConnectionFactoryOptions connectionFactoryOptions, Predicate<Option<?>> filter) {
+            Assert.requireNonNull(connectionFactoryOptions, "connectionFactoryOptions must not be null");
+            Assert.requireNonNull(filter, "filter must not be null");
+
+            connectionFactoryOptions.options.forEach((k, v) -> {
+                if (filter.test(k)) {
+                    this.options.put(k, v);
+                }
+            });
+
             return this;
         }
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
@@ -91,7 +91,7 @@ public final class ConnectionFactoryOptions {
     /**
      * Parses a R2DBC Connection URL and returns the parsed {@link ConnectionFactoryOptions}.
      * URL format:
-     * {@code r2dbc:driver[:protocol[:subprotocols]}://[user:password@]host[:port][/path][?option=value]}.
+     * {@code r2dbc:driver[:protocol]}://[user:password@]host[:port][/path][?option=value]}.
      *
      * @param url the R2DBC URL.
      * @return the parsed {@link ConnectionFactoryOptions}.

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
@@ -88,6 +88,18 @@ public final class ConnectionFactoryOptions {
     }
 
     /**
+     * Parses a R2DBC Connection URL and returns the parsed {@link ConnectionFactoryOptions}.
+     * URL format:
+     * {@code r2dbc:driver[:protocol[:subprotocols]}://[user:password@]host[:port][/path][?option=value]}.
+     *
+     * @param url the R2DBC URL.
+     * @return the parsed {@link ConnectionFactoryOptions}.
+     */
+    public static ConnectionFactoryOptions parse(CharSequence url) {
+        return ConnectionUrlParser.parseQuery(Assert.requireNonNull(url, "R2DBC Connection URL must not be null"));
+    }
+
+    /**
      * Returns the value for an option if it exists.
      *
      * @param option the option to retrieve the value for
@@ -155,7 +167,7 @@ public final class ConnectionFactoryOptions {
     }
 
     /**
-     * A builder for {@link ConnectionFactoryOptions} isntances.
+     * A builder for {@link ConnectionFactoryOptions} instances.
      * <p>
      * <i>This class is not threadsafe</i>
      */
@@ -214,4 +226,5 @@ public final class ConnectionFactoryOptions {
         }
 
     }
+
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionUrlParser.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionUrlParser.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Parser for R2DBC URL's.
+ * Parser for R2DBC Connection URL's.
  */
 abstract class ConnectionUrlParser {
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionUrlParser.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionUrlParser.java
@@ -1,0 +1,493 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.BitSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Parser for R2DBC URL's.
+ */
+class ConnectionUrlParser {
+
+    private static final Set<String> PROHIBITED_QUERY_OPTIONS = Stream.of(ConnectionFactoryOptions.DATABASE,
+        ConnectionFactoryOptions.DRIVER, ConnectionFactoryOptions.HOST, ConnectionFactoryOptions.PASSWORD,
+        ConnectionFactoryOptions.PORT, ConnectionFactoryOptions.PROTOCOL, ConnectionFactoryOptions.USER).map(Option::name)
+        .collect(Collectors.toSet());
+
+    /**
+     * Scheme for R2DBC.
+     */
+    private static final String R2DBC_SCHEME = "r2dbc";
+
+    /**
+     * Scheme for R2DBC with SSL enabled.
+     */
+    private static final String R2DBC_SSL_SCHEME = "r2dbcs";
+
+    static void validate(String url) {
+
+        Assert.requireNonNull(url, "URL must not be null");
+
+        if (!url.startsWith(R2DBC_SCHEME + ":") && !url.startsWith(R2DBC_SSL_SCHEME + ":")) {
+            throw new IllegalArgumentException(String.format("URL %s does not start with the %s scheme", url, R2DBC_SCHEME));
+        }
+
+        int schemeSpecificPartIndex = url.indexOf("://");
+        int driverPartIndex;
+
+        if (url.startsWith(R2DBC_SSL_SCHEME)) {
+            driverPartIndex = R2DBC_SSL_SCHEME.length() + 1;
+        } else {
+            driverPartIndex = R2DBC_SCHEME.length() + 1;
+        }
+
+        if (schemeSpecificPartIndex == -1 || driverPartIndex >= schemeSpecificPartIndex) {
+            throw new IllegalArgumentException(String.format("Invalid URL: %s", url));
+        }
+
+        String[] schemeParts = url.split(":", 3);
+
+        String driver = schemeParts[1];
+        if (driver.trim().isEmpty()) {
+            throw new IllegalArgumentException(String.format("Empty driver in URL: %s", url));
+        }
+    }
+
+    static ConnectionFactoryOptions parseQuery(CharSequence url) {
+
+        String urlToUse = url.toString();
+        validate(urlToUse);
+
+        // R2DBC URL must contain at least two colons in the scheme part (r2dbc:<some driver>:).
+        String[] schemeParts = urlToUse.split(":", 3);
+
+        String scheme = schemeParts[0];
+        String driver = schemeParts[1];
+        String protocol = schemeParts[2];
+
+        int schemeSpecificPartIndex = urlToUse.indexOf("://");
+        String rewrittenUrl = scheme + urlToUse.substring(schemeSpecificPartIndex);
+
+        URI uri = URI.create(rewrittenUrl);
+
+        ConnectionFactoryOptions.Builder builder = ConnectionFactoryOptions.builder();
+
+        if (scheme.equals(R2DBC_SSL_SCHEME)) {
+            builder.option(ConnectionFactoryOptions.SSL, true);
+        }
+
+        builder.option(ConnectionFactoryOptions.DRIVER, driver);
+
+        int protocolEnd = protocol.indexOf("://");
+        if (protocolEnd != -1) {
+            protocol = protocol.substring(0, protocolEnd);
+
+            if (!protocol.trim().isEmpty()) {
+                builder.option(ConnectionFactoryOptions.PROTOCOL, protocol);
+            }
+        }
+
+        if (hasText(uri.getHost())) {
+            builder.option(ConnectionFactoryOptions.HOST, decode(uri.getHost().trim()).toString());
+
+            if (hasText(uri.getRawUserInfo())) {
+                parseUserinfo(uri.getRawUserInfo(), builder);
+            }
+        } else if (hasText(uri.getRawAuthority())) {
+
+            String authorityToUse = uri.getRawAuthority();
+
+            if (authorityToUse.contains("@")) {
+
+                int atIndex = authorityToUse.indexOf('@');
+                String userinfo = authorityToUse.substring(0, atIndex);
+                authorityToUse = authorityToUse.substring(atIndex + 1);
+
+                if (!userinfo.isEmpty()) {
+                    parseUserinfo(userinfo, builder);
+                }
+            }
+
+            builder.option(ConnectionFactoryOptions.HOST, decode(authorityToUse.trim()).toString());
+        }
+
+        if (uri.getPort() != -1) {
+            builder.option(ConnectionFactoryOptions.PORT, uri.getPort());
+        }
+
+        if (hasText(uri.getPath())) {
+            String path = uri.getPath().substring(1).trim();
+            if (hasText(path)) {
+                builder.option(ConnectionFactoryOptions.DATABASE, path);
+            }
+        }
+
+        if (hasText(uri.getRawQuery())) {
+            parseQuery(uri.getRawQuery().trim(), (k, v) -> {
+
+                if (PROHIBITED_QUERY_OPTIONS.contains(k)) {
+                    throw new IllegalArgumentException(
+                        String.format("URL %s must not declare option %s in the query string", url, k));
+                }
+
+                builder.option(Option.valueOf(k), v);
+            });
+        }
+
+        return builder.build();
+    }
+
+    private static boolean hasText(@Nullable String s) {
+        return s != null && !s.isEmpty();
+    }
+
+    private static void parseUserinfo(String s, ConnectionFactoryOptions.Builder builder) {
+
+        String[] userinfo = s.split(":", 2);
+
+        String user = decode(userinfo[0]).toString();
+        CharSequence password = decode(userinfo[1]);
+
+        builder.option(ConnectionFactoryOptions.USER, user).option(ConnectionFactoryOptions.PASSWORD, password);
+    }
+
+    /**
+     * Simplified fork of {@link URLDecoder}. The supplied encoding is used to determine what characters are represented
+     * by any consecutive sequences of the form {@code %xy}.
+     *
+     * @param s the {@link CharSequence} to decode.
+     * @return the newly decoded {@code CharSequence}.
+     * @see URLDecoder
+     */
+    private static CharSequence decode(CharSequence s) {
+
+        boolean encoded = false;
+        int numChars = s.length();
+        StringBuffer sb = new StringBuffer(numChars > 500 ? numChars / 2 : numChars);
+        int i = 0;
+
+        char c;
+        byte[] bytes = null;
+
+        while (i < numChars) {
+            c = s.charAt(i);
+            switch (c) {
+                case '+':
+                    sb.append(' ');
+                    i++;
+                    encoded = true;
+                    break;
+                case '%':
+                    /*
+                     * Starting with this instance of %, process all
+                     * consecutive substrings of the form %xy. Each
+                     * substring %xy will yield a byte. Convert all
+                     * consecutive  bytes obtained this way to whatever
+                     * character(s) they represent in the provided
+                     * encoding.
+                     */
+                    try {
+
+                        // (numChars-i)/3 is an upper bound for the number
+                        // of remaining bytes
+                        if (bytes == null) {
+                            bytes = new byte[(numChars - i) / 3];
+                        }
+                        int pos = 0;
+
+                        while (((i + 2) < numChars) && (c == '%')) {
+                            int v = Integer.parseInt(s.subSequence(i + 1, i + 3).toString(), 16);
+                            if (v < 0) {
+                                throw new IllegalArgumentException(
+                                    "URLDecoder: Illegal hex characters in escape (%) pattern - negative value");
+                            }
+                            bytes[pos++] = (byte) v;
+                            i += 3;
+                            if (i < numChars) {
+                                c = s.charAt(i);
+                            }
+                        }
+
+                        // A trailing, incomplete byte encoding such as
+                        // "%x" will cause an exception to be thrown
+
+                        if ((i < numChars) && (c == '%')) {
+                            throw new IllegalArgumentException("URLDecoder: Incomplete trailing escape (%) pattern");
+                        }
+
+                        sb.append(StandardCharsets.UTF_8.decode(ByteBuffer.wrap(bytes, 0, pos)));
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException(
+                            "URLDecoder: Illegal hex characters in escape (%) pattern - " + e.getMessage());
+                    }
+                    encoded = true;
+                    break;
+                default:
+                    sb.append(c);
+                    i++;
+                    break;
+            }
+        }
+
+        return (encoded ? sb : s);
+    }
+
+    /**
+     * Parse a {@link CharSequence query string} and decode percent encoding according to RFC3986, section 2.4.
+     * Percent-encoded octets are decoded using UTF-8.
+     *
+     * @param s             input text
+     * @param tupleConsumer consumer notified on tuple creation
+     * @link https://tools.ietf.org/html/rfc3986#section-2.4
+     * @see StandardCharsets#UTF_8
+     */
+    static void parseQuery(CharSequence s, BiConsumer<String, String> tupleConsumer) {
+
+        QueryStringParser parser = QueryStringParser.create(s);
+
+        while (!parser.isFinished()) {
+
+            CharSequence name = parser.parseName();
+            CharSequence value = parser.isFinished() ? null : parser.parseValue();
+
+            if (name.length() != 0 && value != null) {
+                tupleConsumer.accept(decode(name).toString(), decode(value).toString());
+            }
+        }
+    }
+
+    /**
+     * Parser for RFC3986-style query strings such as {@code key1=value1&key2=value2}.
+     *
+     * @link https://tools.ietf.org/html/rfc3986#section-3.4
+     */
+    static class QueryStringParser {
+
+        /**
+         * carriage return (ASCII 13).
+         */
+        static final char CR = '\r';
+
+        /**
+         * line feed (ASCII 10).
+         */
+        static final char LF = '\n';
+
+        /**
+         * space (ASCII 32).
+         */
+        static final char SPACE = ' ';
+
+        /**
+         * horizontal-tab (ASCII 9).
+         */
+        static final char TAB = '\t';
+
+        private final CharSequence input;
+
+        private final Cursor state;
+
+        private final BitSet delimiters = new BitSet(256);
+
+        private QueryStringParser(CharSequence input) {
+            this.input = input;
+            this.state = new Cursor(input.length());
+            this.delimiters.set('&'); // ampersand, tuple separator
+        }
+
+        /**
+         * Creates a new {@link QueryStringParser} given the {@code input}.
+         *
+         * @param input must not be {@code null}
+         * @return a new {@link QueryStringParser} instance
+         */
+        static QueryStringParser create(CharSequence input) {
+            return new QueryStringParser(input);
+        }
+
+        /**
+         * Returns whether parsing is finished.
+         *
+         * @return {@literal true} if parsing is finished; {@literal false} otherwise
+         */
+        boolean isFinished() {
+            return state.isFinished();
+        }
+
+        /**
+         * Extracts a sequence of characters identifying the name of the key-value tuple.
+         *
+         * @return name of the key-value pair
+         * @throws IllegalStateException if parsing is already {@link #isFinished() finished}
+         */
+        CharSequence parseName() {
+
+            if (this.state.isFinished()) {
+                throw new IllegalStateException("Parsing is finished");
+            }
+
+            delimiters.set('=');
+            return parseToken();
+        }
+
+        /**
+         * Extracts a sequence of characters identifying the name of the key-value tuple.
+         *
+         * @return value of the key-value pair, can be {@code null}
+         * @throws IllegalStateException if parsing is already {@link #isFinished() finished}
+         */
+        @Nullable
+        CharSequence parseValue() {
+            if (this.state.isFinished()) {
+                throw new IllegalStateException("Parsing is finished");
+            }
+
+            int delim = this.input.charAt(this.state.getParsePosition());
+            this.state.incrementParsePosition();
+
+            if (delim == '=') {
+                delimiters.clear('=');
+                try {
+                    return parseToken();
+                } finally {
+                    if (!isFinished()) {
+                        this.state.incrementParsePosition();
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /**
+         * Extracts from the sequence of chars a token terminated with any of the given delimiters discarding semantically
+         * insignificant whitespace characters.
+         */
+        private CharSequence parseToken() {
+
+            StringBuilder dst = new StringBuilder();
+
+            boolean whitespace = false;
+
+            while (!this.state.isFinished()) {
+                char current = this.input.charAt(this.state.getParsePosition());
+                if (delimiters.get(current)) {
+                    break;
+                } else if (isWhitespace(current)) {
+                    skipWhiteSpace();
+                    whitespace = true;
+                } else {
+                    if (whitespace && dst.length() > 0) {
+                        dst.append(' ');
+                    }
+                    copyContent(dst);
+                    whitespace = false;
+                }
+            }
+
+            return dst;
+        }
+
+        /**
+         * Skips semantically insignificant whitespace characters and moves the cursor to the closest non-whitespace
+         * character.
+         */
+        private void skipWhiteSpace() {
+            int pos = this.state.getParsePosition();
+
+            for (int i = this.state.getParsePosition(); i < this.state.getUpperBound(); i++) {
+                char current = this.input.charAt(i);
+                if (!isWhitespace(current)) {
+                    break;
+                }
+                pos++;
+            }
+
+            this.state.updatePos(pos);
+        }
+
+        /**
+         * Transfers content into the destination buffer until a whitespace character or any of the given delimiters is
+         * encountered.
+         *
+         * @param target destination buffer
+         */
+        private void copyContent(StringBuilder target) {
+            int pos = this.state.getParsePosition();
+
+            for (int i = this.state.getParsePosition(); i < this.state.getUpperBound(); i++) {
+                char current = this.input.charAt(i);
+                if (delimiters.get(current) || isWhitespace(current)) {
+                    break;
+                }
+                pos++;
+                target.append(current);
+            }
+
+            this.state.updatePos(pos);
+        }
+
+        private static boolean isWhitespace(char ch) {
+            return ch == SPACE || ch == TAB || ch == CR || ch == LF;
+        }
+    }
+
+    /**
+     * Parse cursor state.
+     */
+    private static class Cursor {
+
+        private final int upperBound;
+
+        private int pos;
+
+        Cursor(int upperBound) {
+            this.upperBound = upperBound;
+            this.pos = 0;
+        }
+
+        void incrementParsePosition() {
+            updatePos(getParsePosition() + 1);
+        }
+
+        int getUpperBound() {
+            return this.upperBound;
+        }
+
+        int getParsePosition() {
+            return this.pos;
+        }
+
+        void updatePos(final int pos) {
+            this.pos = pos;
+        }
+
+        boolean isFinished() {
+            return this.pos >= this.upperBound;
+        }
+
+    }
+
+}

--- a/r2dbc-spi/src/test/java/io/r2dbc/spi/ConnectionUrlParserUnitTests.java
+++ b/r2dbc-spi/src/test/java/io/r2dbc/spi/ConnectionUrlParserUnitTests.java
@@ -102,6 +102,18 @@ final class ConnectionUrlParserUnitTests {
         assertThat(parseQuery("r2dbc:foo://myhost/database?foo=a%26b%26c%3Dd")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasNoPort().hasDatabase("database").hasOption("foo", "a&b&c=d");
     }
 
+    @Test
+    void rejectsWellKnownPropertiesInQueryString() {
+
+        assertThatThrownBy(() -> parseQuery("r2dbc:foo://myhost/database?driver=foo")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> parseQuery("r2dbc:foo://myhost/database?protocol=foo")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> parseQuery("r2dbc:foo://myhost/database?user=foo")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> parseQuery("r2dbc:foo://myhost/database?password=foo")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> parseQuery("r2dbc:foo://myhost/database?host=foo")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> parseQuery("r2dbc:foo://myhost/database?port=foo")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> parseQuery("r2dbc:foo://myhost/database?database=foo")).isInstanceOf(IllegalArgumentException.class);
+    }
+
     /**
      * Create an assertion for a {@link ConnectionFactoryOptions}.
      *

--- a/r2dbc-spi/src/test/java/io/r2dbc/spi/ConnectionUrlParserUnitTests.java
+++ b/r2dbc-spi/src/test/java/io/r2dbc/spi/ConnectionUrlParserUnitTests.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static io.r2dbc.spi.ConnectionUrlParser.parseQuery;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link ConnectionUrlParser}.
+ */
+final class ConnectionUrlParserUnitTests {
+
+    @Test
+    void shouldRejectEmptyUrl() {
+        assertThatThrownBy(() -> ConnectionUrlParser.validate(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ConnectionUrlParser.validate("")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRejectNonR2dbcUrl() {
+        assertThatThrownBy(() -> ConnectionUrlParser.validate("foo://host")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ConnectionUrlParser.validate("R2DBC:foo://")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRejectMalformedUrl() {
+        assertThatThrownBy(() -> ConnectionUrlParser.validate("r2dbc://host")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ConnectionUrlParser.validate("r2dbc:://host")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ConnectionUrlParser.validate("r2dbc: ://host")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ConnectionUrlParser.validate("r2dbc:host")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ConnectionUrlParser.validate("r2dbc:/host")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldParseSingleHostUrl() {
+        assertThat(parseQuery("r2dbc:foo://myhost")).hasDriver("foo").hasNotOption(ConnectionFactoryOptions.SSL).hasNoProtocol().hasHost("myhost").hasNoPort().hasNoDatabase().hasNotOption(ConnectionFactoryOptions.SSL);
+    }
+
+    @Test
+    void shouldParseSecure() {
+        assertThat(parseQuery("r2dbcs:foo://myhost")).hasDriver("foo").hasOption(ConnectionFactoryOptions.SSL).hasHost("myhost").hasNoPort().hasNoDatabase();
+    }
+
+    @Test
+    void shouldParseSingleHostUrlWithProtocol() {
+        assertThat(parseQuery("r2dbc:foo:bar://myhost")).hasDriver("foo").hasProtocol("bar").hasHost("myhost").hasNoPort().hasNoDatabase().hasNotOption(ConnectionFactoryOptions.SSL);
+    }
+
+    @Test
+    void shouldParseSingleHostAndPort() {
+        assertThat(parseQuery("r2dbc:foo://myhost:4711")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasPort(4711).hasNoUser().hasNoDatabase();
+    }
+
+    @Test
+    void hasMultipleHosts() {
+        assertThat(parseQuery("r2dbc:foo://host1,host2")).hasDriver("foo").hasNoProtocol().hasHost("host1,host2").hasNoPort().hasNoUser().hasNoDatabase();
+        assertThat(parseQuery("r2dbc:foo://host1:123,host2:456")).hasDriver("foo").hasNoProtocol().hasHost("host1:123,host2:456").hasNoPort().hasNoUser().hasNoDatabase();
+    }
+
+    @Test
+    void hasAuthentication() {
+        assertThat(parseQuery("r2dbc:foo://user:password@myhost:4711")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasPort(4711).hasUser("user").hasNoDatabase();
+
+        assertThat(parseQuery("r2dbc:foo://a%26b%26f%3Ac%3Dd:password%204%21@myhost:4711")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasPassword("password 4!").hasPort(4711).hasUser("a&b" +
+            "&f:c=d").hasNoDatabase();
+    }
+
+    @Test
+    void hasMultipleHostsWithAuthentication() {
+        assertThat(parseQuery("r2dbc:foo://user:password@host1,host2")).hasDriver("foo").hasNoProtocol().hasHost("host1,host2").hasNoPort().hasUser("user").hasNoDatabase();
+        assertThat(parseQuery("r2dbc:foo://user:password@host1:123,host2:456")).hasDriver("foo").hasNoProtocol().hasHost("host1:123,host2:456").hasNoPort().hasUser("user").hasNoDatabase();
+    }
+
+    @Test
+    void hasDatabase() {
+        assertThat(parseQuery("r2dbc:foo://myhost/")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasNoPort().hasNoDatabase();
+        assertThat(parseQuery("r2dbc:foo://myhost/database")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasNoPort().hasDatabase("database");
+        assertThat(parseQuery("r2dbc:foo://myhost/a%26b%26c%3Dd")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasNoPort().hasDatabase("a&b&c=d");
+    }
+
+    @Test
+    void parsesQueryString() {
+        assertThat(parseQuery("r2dbc:foo://myhost/database?foo=bar")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasNoPort().hasDatabase("database").hasOption("foo", "bar");
+        assertThat(parseQuery("r2dbc:foo://myhost/database?foo=a%26b%26c%3Dd")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasNoPort().hasDatabase("database").hasOption("foo", "a&b&c=d");
+    }
+
+    /**
+     * Create an assertion for a {@link ConnectionFactoryOptions}.
+     *
+     * @param actual
+     */
+    public static ConnectionFactoryOptionsAssert assertThat(ConnectionFactoryOptions actual) {
+        return new ConnectionFactoryOptionsAssert(actual);
+    }
+
+    static class ConnectionFactoryOptionsAssert extends AbstractObjectAssert<ConnectionFactoryOptionsAssert, ConnectionFactoryOptions> {
+
+        private ConnectionFactoryOptionsAssert(ConnectionFactoryOptions actual) {
+            super(actual, ConnectionFactoryOptionsAssert.class);
+        }
+
+
+        ConnectionFactoryOptionsAssert hasOption(Option<?> option) {
+
+            isNotNull();
+            actual.getRequiredValue(option);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasNotOption(Option<?> option) {
+
+            isNotNull();
+            Assertions.assertThat(actual.hasOption(option)).describedAs(option.name()).isFalse();
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasOption(String option, String value) {
+
+            isNotNull();
+            Assertions.assertThat(actual.getRequiredValue(Option.valueOf(option)).toString()).describedAs("Option " + option).isEqualTo(value);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasHost(String host) {
+
+            Assertions.assertThat(actual.getRequiredValue(ConnectionFactoryOptions.HOST)).describedAs("Host").isEqualTo(host);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasNoPort() {
+
+            hasNotOption(ConnectionFactoryOptions.PORT);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasPort() {
+
+            hasOption(ConnectionFactoryOptions.PORT);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasPort(int port) {
+
+            isNotNull();
+            Assertions.assertThat(actual.getRequiredValue(ConnectionFactoryOptions.PORT)).describedAs("Port").isEqualTo(port);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasDriver(String driver) {
+
+            isNotNull();
+            Assertions.assertThat(actual.getRequiredValue(ConnectionFactoryOptions.DRIVER)).describedAs("Driver").isEqualTo(driver);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasNoProtocol() {
+
+            hasNotOption(ConnectionFactoryOptions.PROTOCOL);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasProtocol() {
+
+            hasOption(ConnectionFactoryOptions.PROTOCOL);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasProtocol(String protocol) {
+
+            isNotNull();
+            Assertions.assertThat(actual.getRequiredValue(ConnectionFactoryOptions.PROTOCOL)).describedAs("Protocol").isEqualTo(protocol);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasNoDatabase() {
+
+            hasNotOption(ConnectionFactoryOptions.DATABASE);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasDatabase() {
+
+            hasOption(ConnectionFactoryOptions.DATABASE);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasDatabase(String database) {
+
+            isNotNull();
+            Assertions.assertThat(actual.getRequiredValue(ConnectionFactoryOptions.DATABASE)).describedAs("Database").isEqualTo(database);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasNoUser() {
+
+            hasNotOption(ConnectionFactoryOptions.USER);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasUser() {
+
+            hasOption(ConnectionFactoryOptions.USER);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasUser(String user) {
+
+            isNotNull();
+            Assertions.assertThat(actual.getRequiredValue(ConnectionFactoryOptions.USER)).describedAs("User").isEqualTo(user);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasNoPassword() {
+
+            isNotNull();
+            hasNotOption(ConnectionFactoryOptions.PASSWORD);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasPassword() {
+
+            isNotNull();
+            hasOption(ConnectionFactoryOptions.PASSWORD);
+
+            return this;
+        }
+
+        ConnectionFactoryOptionsAssert hasPassword(String password) {
+
+            isNotNull();
+            Assertions.assertThat(actual.getRequiredValue(ConnectionFactoryOptions.PASSWORD).toString()).describedAs("Password").isEqualTo(password);
+
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 4 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 6 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/ with 1 occurrences migrated to:  
  https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/ ([https](https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 8 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences