### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,10 @@
   -->
 
 <project
-        xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-                http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/r2dbc-spec/pom.xml
+++ b/r2dbc-spec/pom.xml
@@ -15,10 +15,10 @@
   -->
 
 <project
-        xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-                http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/r2dbc-spec/src/main/assembly/static-resources.xml
+++ b/r2dbc-spec/src/main/assembly/static-resources.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+<assembly xmlns="https://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="https://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd">
 
     <id>resources</id>
     <formats>

--- a/r2dbc-spi-test/pom.xml
+++ b/r2dbc-spi-test/pom.xml
@@ -15,10 +15,10 @@
   -->
 
 <project
-        xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-                http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/r2dbc-spi/pom.xml
+++ b/r2dbc-spi/pom.xml
@@ -15,10 +15,10 @@
   -->
 
 <project
-        xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-                http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://maven.apache.org/POM/4.0.0 (404) with 8 occurrences migrated to:  
  https://maven.apache.org/POM/4.0.0 ([https](https://maven.apache.org/POM/4.0.0) result 404).
* [ ] http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 (404) with 2 occurrences migrated to:  
  https://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 ([https](https://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://maven.apache.org/xsd/assembly-1.1.3.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/assembly-1.1.3.xsd ([https](https://maven.apache.org/xsd/assembly-1.1.3.xsd) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 4 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://www.w3.org/2001/XMLSchema-instance with 5 occurrences migrated to:  
  https://www.w3.org/2001/XMLSchema-instance ([https](https://www.w3.org/2001/XMLSchema-instance) result 200).