### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -73,10 +73,10 @@ Backports to prior versions will be considered on a case-by-case basis and refle
 3. Use short branch names, preferably based on the GitHub issue (e.g. `gh-1234`), or otherwise using succinct, lower-case, dash (-) delimited names, such as `fix-warnings`.
 
 4. Choose the granularity of your commits consciously and squash commits that represent multiple edits or corrections of the same logical change. 
-See http://git-scm.com/book/en/Git-Tools-Rewriting-History[Rewriting History section of Pro Git] for an overview of streamlining commit history.
+See https://git-scm.com/book/en/Git-Tools-Rewriting-History[Rewriting History section of Pro Git] for an overview of streamlining commit history.
 
 5. Format commit messages using 55 characters for the subject line, 72 lines for the description, followed by related issues, e.g. `[resolves #1234]`
-See the http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines[Commit Guidelines section of Pro Git] for best practices around commit messages and use `git log` to see some examples.
+See the https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines[Commit Guidelines section of Pro Git] for best practices around commit messages and use `git log` to see some examples.
 
 5. List the GitHub issue number in the PR description.
 

--- a/r2dbc-spec/src/main/asciidoc/introduction.adoc
+++ b/r2dbc-spec/src/main/asciidoc/introduction.adoc
@@ -18,7 +18,7 @@ The R2DBC SPI can also be used to interact with multiple data sources in a distr
 R2DBC targets primarily, but is not limited to, relational databases.
 It aims for a range of data sources whose query and statement interface is based on SQL (or a SQL-like dialect) and represent their data in a tabular form.
 
-A key difference between R2DBC and imperative data access SPIs is the deferred nature of execution. R2DBC is therefore based on http://www.reactive-streams.org/[Reactive Streams] to use the concept of `Publisher` and `Subscriber` to allow non-blocking backpressure-aware data access.
+A key difference between R2DBC and imperative data access SPIs is the deferred nature of execution. R2DBC is therefore based on https://www.reactive-streams.org/[Reactive Streams] to use the concept of `Publisher` and `Subscriber` to allow non-blocking backpressure-aware data access.
 
 [[introduction.target-audience]]
 == Target Audience
@@ -45,7 +45,7 @@ Thanks also go to Ollie without whom this initiative would not even exist.
 [[introduction.following]]
 == Following Development
 
-For information on R2DBC source code repositories, nightly builds, and snapshot artifacts, see the http://r2dbc.io/resources/[R2DBC] homepage.
+For information on R2DBC source code repositories, nightly builds, and snapshot artifacts, see the https://r2dbc.io/resources/[R2DBC] homepage.
 You can help make R2DBC best serve the needs of the community by interacting with developers through the community.
 To follow developer activity, look for the mailing list information on the R2DBC homepage.
 If you encounter a bug or want to suggest an improvement, please create a ticket on the R2DBC issue tracker.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://r2dbc.io/resources/ with 1 occurrences migrated to:  
  https://r2dbc.io/resources/ ([https](https://r2dbc.io/resources/) result 200).
* [ ] http://www.reactive-streams.org/ with 1 occurrences migrated to:  
  https://www.reactive-streams.org/ ([https](https://www.reactive-streams.org/) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project with 1 occurrences migrated to:  
  https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project ([https](https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project) result 302).
* [ ] http://git-scm.com/book/en/Git-Tools-Rewriting-History with 1 occurrences migrated to:  
  https://git-scm.com/book/en/Git-Tools-Rewriting-History ([https](https://git-scm.com/book/en/Git-Tools-Rewriting-History) result 302).