### PR TITLE
Add detailed specification for Result and Row

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/index.adoc
+++ b/r2dbc-spec/src/main/asciidoc/index.adoc
@@ -26,6 +26,8 @@ include::overview.adoc[leveloffset=+1]
 
 include::connections.adoc[leveloffset=+1]
 
+include::result.adoc[leveloffset=+1]
+
 include::row-metadata.adoc[leveloffset=+1]
 
 include::exceptions.adoc[leveloffset=+1]

--- a/r2dbc-spec/src/main/asciidoc/result.adoc
+++ b/r2dbc-spec/src/main/asciidoc/result.adoc
@@ -1,0 +1,141 @@
+[[results]]
+= Results
+
+This section explains the `Result` interface and the related `Row` interface. It also describes related topics including result consumption.
+
+[[results.characteristics]]
+== Result Characteristics
+
+`Result` objects are forward-only and read-only objects that allow consumption of two result types:
+
+* Tabular results
+* Update count
+
+Results move forward from the first `Row` to the last one. After emitting the last row, a `Result` object gets invalidated and rows from the same `Result` object cannot be longer consumed.
+Rows contained in the result depend on how the underlying database materializes the results.
+That is, it contains the rows that satisfy the query at either the time the query is executed or as the rows are retrieved.
+An R2DBC driver can obtain a Result either directly or by using cursors.
+
+`Result` reports the number of rows affected for SQL statements such as update for SQL Data Manipulation Language (DML) statements.
+The update count may be empty for statements that do not modify rows.
+After emitting the update count, a `Result` object gets invalidated and rows from the same `Result` object cannot be longer consumed.
+
+.Consuming update count
+====
+[source,java]
+----
+// result is a Result object
+Publisher<Integer> rowsUpdated = result.getRowsUpdated();
+----
+====
+
+The streaming nature of a result allows either consumption of tabular results or update count.
+Depending on how the underlying database materializes results, an R2DBC driver can lift this limitation.
+
+A `Result` object is emitted for each statement result in a forward-only direction.
+
+[[results.creating]]
+== Creating `Result` Objects
+
+A `Result` object is most often created as the result of executing a `Statement` object.
+The `Statement` method `execute()` returns a `Publisher` that emits `Result` objects as result of statement execution.
+
+.Creating a `Result` object
+====
+[source,java]
+----
+// connection is a Connection object
+Statement statement = connection.createStatement("SELECT title, author FROM books");
+Publisher<? extends Result> results = statement.execute();
+----
+====
+
+The `Result` object will emit a `Row` for each row in the table `books`, containing the two columns `title` and `author`.
+The following sections detail how these rows and columns can be consumed.
+
+[[results.cursor]]
+=== Cursor Movement
+
+`Result` objects can be backed by direct results (i. e. a query that returns results directly) or by cursors.
+By consuming `Row` objects, an R2DBC driver advances the cursor position.
+Thus external cursor navigation is not possible.
+
+Canceling subscription of tabular results stops cursor reads and releases resources associated with the `Result` object.
+
+[[rows]]
+== Rows
+
+A `Row` object represents a single row of tabular results.
+
+[[row.values]]
+=== Retrieving Values
+
+The `Result` interface provides a `map(…)` method for retrieving values from `Row` objects.
+The `map` method accepts `BiFunction` (also referred to as mapping function) object that accepts `Row` and `RowMetadata`.
+The mapping function is called upon row emission with `Row` and `RowMetadata` objects.
+A `Row` is only valid during the mapping function callback and are invalid outside of the mapping function callback.
+Thus `Row` objects must be entirely consumed in the mapping function.
+
+The section <<rowmetadata>> contains additional details on metadata.
+
+[[row.methods]]
+== Interface Methods
+
+The following methods are available on the `Row` interface:
+
+* `Object get(Object)`
+* `<T> T get(Object, Class<T>)`
+
+Both `get` methods accept a column identifier that can be either the column name or the column index.
+Column names used as input to the `get` methods are case insensitive.
+Column names do not necessarily reflect the column names how they are in the underlying tables but rather how columns are represented (e.g. aliased) in the result.
+
+.Creating and Consuming a `Row` using its index
+====
+[source,java]
+----
+// result is a Result object
+Publisher<Object> values = result.map((row, rowMetadata) -> row.get(0));
+----
+====
+
+.Creating and Consuming a `Row` through its column name
+====
+[source,java]
+----
+// result is a Result object
+Publisher<Object> titles = result.map((row, rowMetadata) -> row.get("title"));
+----
+====
+
+Calling `get` without specifying a target type returns a suitable value representation according to <<datatypes.mapping>>.
+Specifying a target type, the R2DBC driver attempts to convert the value to the target type.
+
+.Creating and Consuming a `Row` with type conversion
+====
+[source,java]
+----
+// result is a Result object
+Publisher<String> values = result.map((row, rowMetadata) -> row.get(0, String.class));
+----
+====
+
+.Consuming multiple columns from a `Row`
+====
+[source,java]
+----
+// result is a Result object
+Publisher<Book> values = result.map((row, rowMetadata) -> {
+    String title = row.get("title", String.class);
+    String author = row.get("author", String.class);
+
+    return new Book(title, author);
+});
+----
+====
+
+When the column value in the database is SQL `NULL`, it may be returned to the Java application as `null`.
+
+NOTE: `null` values cannot be returned as Reactive Streams values and must be wrapped for subsequent usage.
+
+NOTE: Invalidating a `Row` does *not* release `Blob` and `Clob` objects that were obtained from the `Row`. These objects remain valid for at least the duration of the transaction in which they were created unless their `discard()` method is called.

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/Example.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/Example.java
@@ -38,8 +38,10 @@ import java.nio.charset.StandardCharsets;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 
 public interface Example<T> {
@@ -204,6 +206,32 @@ public interface Example<T> {
     }
 
     @Test
+    default void columnMetadata() {
+        getJdbcOperations().execute("INSERT INTO test_two_column VALUES (100, 'hello')");
+
+        Mono.from(getConnectionFactory().create())
+            .flatMapMany(connection -> Flux.from(connection
+
+                .createStatement("SELECT col1 AS value, col2 AS value FROM test_two_column")
+                .execute())
+                .flatMap(result -> {
+                    return result.map((row, rowMetadata) -> {
+                        Collection<String> columnNames = rowMetadata.getColumnNames();
+                        return Arrays.asList(rowMetadata.getColumnMetadata("value").getName(), rowMetadata.getColumnMetadata("VALUE").getName(), columnNames.contains("value"), columnNames.contains(
+                            "VALUE"));
+                    });
+                })
+                .flatMapIterable(Function.identity())
+                .concatWith(close(connection)))
+            .as(StepVerifier::create)
+            .expectNext("value").as("Column label col1")
+            .expectNext("value").as("Column label col1 (get by uppercase)")
+            .expectNext(true, "getColumnNames.contains(value)")
+            .expectNext(true, "getColumnNames.contains(VALUE)")
+            .verifyComplete();
+    }
+
+    @Test
     default void compoundStatement() {
         getJdbcOperations().execute("INSERT INTO test VALUES (100)");
 
@@ -224,6 +252,7 @@ public interface Example<T> {
     @BeforeEach
     default void createTable() {
         getJdbcOperations().execute("CREATE TABLE test ( value INTEGER )");
+        getJdbcOperations().execute("CREATE TABLE test_two_column ( col1 INTEGER, col2 VARCHAR(100) )");
         getJdbcOperations().execute(String.format("CREATE TABLE blob_test ( value %s )", blobType()));
         getJdbcOperations().execute(String.format("CREATE TABLE clob_test ( value %s )", clobType()));
     }
@@ -231,8 +260,30 @@ public interface Example<T> {
     @AfterEach
     default void dropTable() {
         getJdbcOperations().execute("DROP TABLE test");
+        getJdbcOperations().execute("DROP TABLE test_two_column");
         getJdbcOperations().execute("DROP TABLE blob_test");
         getJdbcOperations().execute("DROP TABLE clob_test");
+    }
+
+    @Test
+    default void duplicateColumnNames() {
+        getJdbcOperations().execute("INSERT INTO test_two_column VALUES (100, 'hello')");
+
+        Mono.from(getConnectionFactory().create())
+            .flatMapMany(connection -> Flux.from(connection
+
+                .createStatement("SELECT col1 AS value, col2 AS value FROM test_two_column")
+                .execute())
+                .flatMap(result -> {
+                    return result.map((row, rowMetadata) -> {
+                        return Arrays.asList(row.get("value"), row.get("VALUE"));
+                    });
+                }).flatMapIterable(Function.identity())
+                .concatWith(close(connection)))
+            .as(StepVerifier::create)
+            .expectNext(100).as("value from col1")
+            .expectNext(100).as("value from col1 (upper case)")
+            .verifyComplete();
     }
 
     /**

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockResult.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockResult.java
@@ -56,8 +56,8 @@ public final class MockResult implements Result {
     }
 
     @Override
-    public <T> Flux<T> map(BiFunction<Row, RowMetadata, ? extends T> f) {
-        Assert.requireNonNull(f, "f must not be null");
+    public <T> Flux<T> map(BiFunction<Row, RowMetadata, ? extends T> mappingFunction) {
+        Assert.requireNonNull(mappingFunction, "f must not be null");
 
         return this.rows
             .zipWith(this.rowMetadata.repeat())
@@ -65,7 +65,7 @@ public final class MockResult implements Result {
                 Row row = tuple.getT1();
                 RowMetadata rowMetadata = tuple.getT2();
 
-                return f.apply(row, rowMetadata);
+                return mappingFunction.apply(row, rowMetadata);
             });
     }
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ColumnMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ColumnMetadata.java
@@ -17,7 +17,7 @@
 package io.r2dbc.spi;
 
 /**
- * Represents the metadata for a column of the results returned from a query. The implementation of all methods except {@link #getName()}  is optional for drivers. Column metadata is optionally
+ * Represents the metadata for a column of the results returned from a query.  The implementation of all methods except {@link #getName()}  is optional for drivers.  Column metadata is optionally
  * available as by-product of statement execution on a best-effort basis.
  */
 public interface ColumnMetadata {
@@ -41,7 +41,7 @@ public interface ColumnMetadata {
     /**
      * Returns the name of the column.
      * <p>
-     * The name does not necessarily reflect the underlying column name but rather how the column is represented (e.g. aliased) in the result.
+     * The name does not necessarily reflect the column names how they are in the underlying tables but rather how columns are represented (e.g. aliased) in the result..
      *
      * @return the name of the column
      */

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Result.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Result.java
@@ -21,7 +21,11 @@ import org.reactivestreams.Publisher;
 import java.util.function.BiFunction;
 
 /**
- * Represents the results of a query against a database.
+ * Represents the results of a query against a database.  Results can be consumed only once by either consuming {@link #getRowsUpdated()} or {@link #map(BiFunction)}.
+ *
+ * <p>A {@link Result} object maintains a consumption state that may be backed by a cursor pointing
+ * to its current row of data. A {@link Result} allows read-only and forward-only consumption of statement results.
+ * Thus, you can consume either {@link #getRowsUpdated()} or {@link #map(BiFunction) Rows} through it only once and only from the first row to the last row.
  */
 public interface Result {
 
@@ -29,17 +33,20 @@ public interface Result {
      * Returns the number of rows updated by a query against a database.  May be empty if the query did not update any rows.
      *
      * @return the number of rows updated by a query against a database
+     * @throws IllegalStateException if the result was consumed
      */
     Publisher<Integer> getRowsUpdated();
 
     /**
-     * Returns a mapping of the rows that are the results of a query against a database.  May be empty if the query did not return any rows.
+     * Returns a mapping of the rows that are the results of a query against a database.  May be empty if the query did not return any rows.  A {@link Row} can be only considered valid within a
+     * {@link BiFunction mapping function} callback.
      *
-     * @param f   the {@link BiFunction} that maps a {@link Row} and {@link RowMetadata} to a value
-     * @param <T> the type of the mapped value
+     * @param mappingFunction the {@link BiFunction} that maps a {@link Row} and {@link RowMetadata} to a value
+     * @param <T>             the type of the mapped value
      * @return a mapping of the rows that are the results of a query against a database
-     * @throws IllegalArgumentException if {@code f} is {@code null}
+     * @throws IllegalArgumentException if {@code mappingFunction} is {@code null}
+     * @throws IllegalStateException    if the result was consumed
      */
-    <T> Publisher<T> map(BiFunction<Row, RowMetadata, ? extends T> f);
+    <T> Publisher<T> map(BiFunction<Row, RowMetadata, ? extends T> mappingFunction);
 
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Row.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Row.java
@@ -16,15 +16,32 @@
 
 package io.r2dbc.spi;
 
+import java.util.function.BiFunction;
+
 /**
  * Represents a row returned from a database query.
+ * Values from columns can be either retrieved by specifying a column name or the column index.
+ * Columns are numbered from 0.  Column names do not necessarily reflect the column names how they are in the underlying tables but rather how columns are represented (e.g. aliased) in the result.
+ *
+ * <p> Column names used as input to getter methods are case insensitive.
+ * When a get method is called with a column name and several columns have the same name, then the value of the first matching column will be returned.
+ * The column name option is designed to be used when column names are used in the SQL query that generated the result set.
+ * Columns that are not explicitly named in the query should be referenced through column indexes.
+ *
+ * <p>For maximum portability, result columns within each {@link Row} should be read in left-to-right order, and each column should be read only once.
+ *
+ * <p>{@link #get(Object)} without specifying a target type returns a suitable value representation.  The R2DBC specification contains a mapping table that shows default mappings between database
+ * types and Java types.
+ * Specifying a target type, the R2DBC driver attempts to convert the value to the target type.
+ * <p>A row is invalidated after consumption in the {@link Result#map(BiFunction) mapping function}.
+ * <p>The number, type and characteristics of columns are described through {@link RowMetadata}
  */
 public interface Row {
 
     /**
      * Returns the value for a column in this row.
      *
-     * @param identifier the identifier of the column
+     * @param identifier the identifier of the column.  Can be either the column index starting at 0 or column name.
      * @param type       the type of item to return. This type must be assignable to, and allows for variance.
      * @param <T>        the type of the item being returned
      * @return the value for a column in this row.  Value can be {@code null}.
@@ -37,7 +54,7 @@ public interface Row {
      * Returns the value for a column in this row using the default type mapping.  The default implementation of this method calls {@link #get(Object, Class)} passing {@link Object} as the type in
      * order to allow the implementation to make the loosest possible match.
      *
-     * @param identifier the identifier of the column
+     * @param identifier the identifier of the column.  Can be either the column index starting at 0 or column name.
      * @return the value for a column in this row.  Value can be {@code null}.
      * @throws IllegalArgumentException if {@code identifier} or {@code type} is {@code null}
      */

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java
@@ -21,13 +21,16 @@ import java.util.NoSuchElementException;
 
 /**
  * Represents the metadata for a row of the results returned from a query.
+ * Metadata for columns can be either retrieved by specifying a column name or the column index.
+ * Columns are numbered from 0.  Column names do not necessarily reflect the column names how they are in the underlying tables but rather how columns are represented (e.g. aliased) in the result.
  */
 public interface RowMetadata {
 
     /**
      * Returns the {@link ColumnMetadata} for one column in this row.
      *
-     * @param identifier the identifier of the column
+     * @param identifier the identifier of the column. Can be either the column index starting at 0 or column name. Column names are case insensitive.  When a get method is called with a column
+     *                   name and several columns have the same name, then the value of the first matching column will be returned.
      * @return the {@link ColumnMetadata} for one column in this row
      * @throws IllegalArgumentException       if {@code identifier} is {@code null} or not supported
      * @throws NoSuchElementException         if there is no column with the name {@code identifier}
@@ -43,7 +46,7 @@ public interface RowMetadata {
     Iterable<? extends ColumnMetadata> getColumnMetadatas();
 
     /**
-     * Returns an unmodifiable collection of column names. Column names do not necessarily reflect the underlying column names but rather how columns are represented (e.g. aliased) in the result.
+     * Returns an unmodifiable collection of column names.
      * <p>
      * Any attempts to modify the returned collection, whether direct or via its iterator, result in an {@link UnsupportedOperationException}.
      * <p>


### PR DESCRIPTION
Document behavior according to specification and driver behavior.

Formalize case-insensitive column name lookups and first column reference for multiple columns with the same name.

Improve `mappingFunction` parameter name.

Add tests for case-insensitive lookups and first column by name.

See #81.