### PR TITLE
Allow url parser to have empty password

### DIFF
--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionUrlParser.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionUrlParser.java
@@ -185,12 +185,23 @@ abstract class ConnectionUrlParser {
 
     private static void parseUserinfo(String s, ConnectionFactoryOptions.Builder builder) {
 
+        if (!s.contains(":")) {
+            String user = decode(s).toString();
+            builder.option(ConnectionFactoryOptions.USER, user);
+            return;
+        }
+
         String[] userinfo = s.split(":", 2);
 
         String user = decode(userinfo[0]).toString();
-        CharSequence password = decode(userinfo[1]);
+        if (!user.isEmpty()) {
+            builder.option(ConnectionFactoryOptions.USER, user);
+        }
 
-        builder.option(ConnectionFactoryOptions.USER, user).option(ConnectionFactoryOptions.PASSWORD, password);
+        CharSequence password = decode(userinfo[1]);
+        if (password.length() != 0) {
+            builder.option(ConnectionFactoryOptions.PASSWORD, password);
+        }
     }
 
     /**

--- a/r2dbc-spi/src/test/java/io/r2dbc/spi/ConnectionUrlParserUnitTests.java
+++ b/r2dbc-spi/src/test/java/io/r2dbc/spi/ConnectionUrlParserUnitTests.java
@@ -77,7 +77,12 @@ final class ConnectionUrlParserUnitTests {
 
     @Test
     void hasAuthentication() {
-        assertThat(parseQuery("r2dbc:foo://user:password@myhost:4711")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasPort(4711).hasUser("user").hasNoDatabase();
+        assertThat(parseQuery("r2dbc:foo://user:password@myhost:4711")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasPort(4711).hasUser("user").hasPassword("password").hasNoDatabase();
+        assertThat(parseQuery("r2dbc:foo://user@myhost:4711")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasPort(4711).hasUser("user").hasNoPassword().hasNoDatabase();
+        assertThat(parseQuery("r2dbc:foo://user:@myhost:4711")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasPort(4711).hasUser("user").hasNoPassword().hasNoDatabase();
+        assertThat(parseQuery("r2dbc:foo://:password@myhost:4711")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasPort(4711).hasNoUser().hasPassword("password").hasNoDatabase();
+        assertThat(parseQuery("r2dbc:foo://@myhost:4711")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasPort(4711).hasNoUser().hasNoPassword().hasNoDatabase();
+        assertThat(parseQuery("r2dbc:foo://:@myhost:4711")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasPort(4711).hasNoUser().hasNoPassword().hasNoDatabase();
 
         assertThat(parseQuery("r2dbc:foo://a%26b%26f%3Ac%3Dd:password%204%21@myhost:4711")).hasDriver("foo").hasNoProtocol().hasHost("myhost").hasPassword("password 4!").hasPort(4711).hasUser("a&b" +
             "&f:c=d").hasNoDatabase();


### PR DESCRIPTION
Fixes userinfo parsing when password is not specified.  
  e.g.:) `..//user@host/...`

Another question is do we want to make `username` to be mandatory or optional when `@` is presented?
Current implementation allows empty `username` such as `..//@host/...`