### PR TITLE
Add specification for Closeable

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/closeable.adoc
+++ b/r2dbc-spec/src/main/asciidoc/closeable.adoc
@@ -1,0 +1,33 @@
+[[closeable]]
+= Closeable Interface
+
+The `io.r2dbc.spi.Closeable` interface provides a mechanism for objects associated with resources to release these once the object is no longer in use. Associated resources are released without blocking the caller.
+
+[[closeable.usage]]
+== Usage
+
+A closeable object is expected to implement the `Closeable` interface so that callers can obtain a `Publisher` to initiate the close operation and get notified upon completion.
+
+.Closing a `Connection`.
+====
+[source,java]
+----
+// connection is a Connection object
+Publisher<Void> close = connection.close();
+----
+====
+
+`Connection` implements `Closeable` as mandatory part of R2DBC. Any stateful object (such as `ConnectionFactory`) can implement `Closeable` to provide a mechanism for releasing its resources.
+
+[[closeable.methods]]
+== Interface Methods
+
+The following methods are available on the `Closeable` interface:
+
+* `close`
+
+[[closeable.close]]
+== `close` Method
+
+The `close` method is used to return a `Publisher` to initiate the close operation and get notified upon completion.
+If the object is already closed, then subscriptions complete successfully and the close operation has no effect.

--- a/r2dbc-spec/src/main/asciidoc/extensions.adoc
+++ b/r2dbc-spec/src/main/asciidoc/extensions.adoc
@@ -5,3 +5,5 @@ This section covers optional extensions to <<compliance.r2dbc,R2DBC Core>>.
 Extensions provide features that are not mandatory to implement by R2DBC implementations.
 
 include::wrapped.adoc[leveloffset=+1]
+
+include::closeable.adoc[leveloffset=+1]

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Closeable.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Closeable.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+/**
+ * A {@link Closeable} is an object that can be closed.  The {@link #close()} method is invoked to release resources that the object is holding (such as open connections).
+ */
+@FunctionalInterface
+public interface Closeable {
+
+    /**
+     * Close this object and release any resources associated with it.  If the object is already closed, then {@link Publisher#subscribe(Subscriber) subscriptions} complete successfully and the
+     * close operation has no effect.
+     *
+     * @return a {@link Publisher} that termination is complete
+     */
+    Publisher<Void> close();
+
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Connection.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Connection.java
@@ -21,7 +21,7 @@ import org.reactivestreams.Publisher;
 /**
  * A single connection to a database.
  */
-public interface Connection {
+public interface Connection extends Closeable {
 
     /**
      * Begins a new transaction.
@@ -35,6 +35,7 @@ public interface Connection {
      *
      * @return a {@link Publisher} that termination is complete
      */
+    @Override
     Publisher<Void> close();
 
     /**


### PR DESCRIPTION
We now provide a `Closeable` interface as an optional extension for stateful resources such as connection pools that typically implement a `ConnectionFactory` interface.

As part of this change, we also make `Connection` extending `Closeable`.

See also #57.