### PR TITLE
Add specification for Statement.fetchSize

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/compliance.adoc
+++ b/r2dbc-spec/src/main/asciidoc/compliance.adoc
@@ -57,6 +57,7 @@ A driver that is compliant with the R2DBC specification must do the following:
   ** `io.r2dbc.spi.Batch`
 * Must implement `io.r2dbc.spi.Statement` interface with the exception of the following optional methods:
   ** `returnGeneratedValues(…)`: Calling this method should be a no-op for drivers not supporting key generation.
+  ** `fetchSize(…)`: Calling this method should be a no-op for drivers not support fetch size hints.
 * Must implement `io.r2dbc.spi.ColumnMetadata` interface with the exception of the following optional methods:
   ** `getPrecision()`
   ** `getScale()`

--- a/r2dbc-spec/src/main/asciidoc/statements.adoc
+++ b/r2dbc-spec/src/main/asciidoc/statements.adoc
@@ -158,3 +158,12 @@ result.map((row, metadata) -> row.get("id"));
 When not specifying column name(s), the R2DBC driver implementation will determine the columns or value to return.
 
 See the R2DBC SPI Specification for more details.
+
+[[statements.performance]]
+== Performance Hints
+
+The `Statement` interface provides a method that can be used to provide hints to a R2DBC driver.
+Calling `fetchSize` applies a fetch size hint to each query produced by the statement.
+Hints provided to the driver through this interface may be ignored by the driver if they are not appropriate or supported.
+Typically, fetch size can be derived from back-pressure hints.
+To optimize for performance it can be useful to provide hints to the driver on a per-statement basis.

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Statement.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Statement.java
@@ -193,4 +193,17 @@ public interface Statement {
         return this;
     }
 
+    /**
+     * Configures {@link Statement} to retrieve a fixed number of rows when fetching results from a query instead deriving fetch size from back pressure.  If called multiple times, only the fetch
+     * size configured in the final invocation will be applied.  If the value specified is zero, then the hint is ignored.
+     * <p>
+     * The default implementation of this method is a no op and the default value is zero.
+     *
+     * @param rows the number of rows to fetch
+     * @return this {@code Statement}
+     */
+    default Statement fetchSize(int rows) {
+        return this;
+    }
+
 }


### PR DESCRIPTION
We now expose a `fetchSize` method to apply fetch size hints to a driver.
This is an optional extension defaulting to no-op for drivers where fetch size is not applicable.

See #73.