### PR TITLE
Add Connection.validate(…) method

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/connections.adoc
+++ b/r2dbc-spec/src/main/asciidoc/connections.adoc
@@ -208,10 +208,23 @@ Publisher<? extends Connection> publisher = factory.create();
 
 The connection is active once it was emitted by the `Publisher` and must be released ("closed") once it is no longer in use.
 
+== Validating `Connection` Objects
+
+The `Connection.validate(…)` method indicates whether the `Connection` is still valid.
+The `ValidationDepth` argument passed to this method indicates until which depth a connection should be validated: Local or Remote.
+
+* `ValidationDepth.LOCAL` requests client-side-only validation without engaging a remote conversation to validate a connection.
+* `ValidationDepth.REMOTE` initiates a remote validation by issuing a query or other means to validate a connection and the remote session.
+
+If `Connection.validate(…)` emits `true`, the `Connection` is still valid.
+If `false` is emitted, the `Connection` is not valid and any attempt to perform database interaction will fail.
+Callers of this method do not expect error signals.
+
 == Closing `Connection` Objects
 
 Calling `Connection.close()` prepares a close handle to release the connection and its associated resources.
 Connections must be closed to ensure proper resource management.
+`Connection.validate(…)` may be used to determine whether a `Connection` has been closed or is still valid.
 
 .Closing a `Connection`
 ====

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/Example.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/Example.java
@@ -22,6 +22,7 @@ import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
+import io.r2dbc.spi.ValidationDepth;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -570,6 +571,23 @@ public interface Example<T> {
             .expectNext(1).as("rows inserted")
             .expectNext(Arrays.asList(100, 200)).as("values from select")
             .expectNext(Collections.singletonList(100)).as("value from select")
+            .verifyComplete();
+    }
+
+    @Test
+    default void validate() {
+
+        Mono.from(getConnectionFactory().create())
+            .flatMapMany(connection -> Flux.concat(connection.validate(ValidationDepth.LOCAL),
+                connection.validate(ValidationDepth.REMOTE),
+                connection.close(),
+                connection.validate(ValidationDepth.LOCAL),
+                connection.validate(ValidationDepth.REMOTE)))
+            .as(StepVerifier::create)
+            .expectNext(true).as("successful local validation")
+            .expectNext(true).as("successful remote validation")
+            .expectNext(false).as("failed local validation after close")
+            .expectNext(false).as("failed remote validation after close")
             .verifyComplete();
     }
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Connection.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Connection.java
@@ -103,4 +103,13 @@ public interface Connection {
      */
     Publisher<Void> setTransactionIsolationLevel(IsolationLevel isolationLevel);
 
+    /**
+     * Validates the connection according to the given {@link ValidationDepth}.
+     *
+     * @param depth the validation depth
+     * @return a {@link Publisher} that indicates whether the validation was successful
+     * @throws IllegalArgumentException if {@code depth} is {@code null}
+     */
+    Publisher<Boolean> validate(ValidationDepth depth);
+
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ValidationDepth.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ValidationDepth.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+/**
+ * Constants indicating validation depth for a {@link Connection}.
+ */
+public enum ValidationDepth {
+
+    /**
+     * Perform a client-side only validation.  Typically to determine whether a connection is still active or other mechanism that does not involve remote communication.
+     */
+    LOCAL,
+
+    /**
+     * Perform a remote connection validations.  Typically by sending a database message or some other mechanism to validate that the database connection and session are active and can be used for
+     * database queries.  Any query submitted by the driver to validate the connection is executed in the context of the current transaction.
+     */
+    REMOTE
+}


### PR DESCRIPTION
Connection exposes with `validate(ValidationDepth)` a method for driver-side connection validation. ValidationDepth signals whether it is a local-only validation without incorporating remote communication or whether a full remote validation should be performed.

Drivers typically either check the local connection state or send a database message, query or any other mechanism, to validate the connection.

See #54.

Merging this PR will break drivers because they have to implement a new method.