### PR TITLE
Updated documentation

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/connections.adoc
+++ b/r2dbc-spec/src/main/asciidoc/connections.adoc
@@ -218,7 +218,7 @@ Connections must be closed to ensure proper resource management.
 [source,java]
 ----
 // connection is a ConnectionFactory object
-Publisher<Void> close = connection.create();
+Publisher<Void> close = connection.close();
 ----
 ====
 

--- a/r2dbc-spec/src/main/asciidoc/statements.adoc
+++ b/r2dbc-spec/src/main/asciidoc/statements.adoc
@@ -103,7 +103,7 @@ The `execute` method validates a parameterized `Statement` and throws an `Illega
 
 Parameterized `Statement` objects accept multiple parameter binding sets submit a batch of commands to the database for execution.
 Batch execution is initiated by invoking the `add()` method on the `Statement` object after providing all parameters.
-After calling `add()`, the next set of parameter bindings is provided by calling bing methods accordingly.
+After calling `add()`, the next set of parameter bindings is provided by calling bind methods accordingly.
 
 .Executing a `Statement` batch
 ====


### PR DESCRIPTION
connection close example code is invoking connection.create() instead of conneciton.close()
word 'bind' misspelled at statements.adoc