### PR TITLE
Correct binding in TestKit

### DIFF
--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/TestKit.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/TestKit.java
@@ -261,7 +261,7 @@ public interface TestKit<T> {
             .flatMapMany(connection -> Flux.from(connection
 
                 .createStatement(String.format("INSERT INTO blob_test VALUES (%s)", getPlaceholder(0)))
-                .bind(getPlaceholder(0), Blob.from(Mono.just(StandardCharsets.UTF_8.encode("test-value"))))
+                .bind(getIdentifier(0), Blob.from(Mono.just(StandardCharsets.UTF_8.encode("test-value"))))
                 .execute())
 
                 .concatWith(close(connection)))
@@ -316,7 +316,7 @@ public interface TestKit<T> {
             .flatMapMany(connection -> Flux.from(connection
 
                 .createStatement(String.format("INSERT INTO clob_test VALUES (%s)", getPlaceholder(0)))
-                .bind(getPlaceholder(0), Clob.from(Mono.just("test-value")))
+                .bind(getIdentifier(0), Clob.from(Mono.just("test-value")))
                 .execute())
 
                 .concatWith(close(connection)))


### PR DESCRIPTION
See #113 

Should use `getIdentifier` instead of `getPlaceholder` when calling `Statement.bind`. In some databases such as MySQL, placeholder not equivalent to identifier.
