### PR TITLE
Use int and String identifier in bind(Object, …) and get(Object, ...) methods

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/result.adoc
+++ b/r2dbc-spec/src/main/asciidoc/result.adoc
@@ -83,12 +83,22 @@ The section <<rowmetadata>> contains additional details on metadata.
 
 The following methods are available on the `Row` interface:
 
+* `Object get(int)`
+* `Object get(String)`
+* `<T> T get(int, Class<T>)`
+* `<T> T get(String, Class<T>)`
+
+Both `get(int[, Class])` methods accept column indexes starting at 0.
+And both `get(String[, Class])` methods accept column names.
+Column names used as input to the `get` methods are case insensitive.
+Column names do not necessarily reflect the column names how they are in the underlying tables but rather how columns are represented (e.g. aliased) in the result.
+
+The following methods have **deprecated** on the `Row` interface:
+
 * `Object get(Object)`
 * `<T> T get(Object, Class<T>)`
 
-Both `get` methods accept a column identifier that can be either the column name or the column index.
-Column names used as input to the `get` methods are case insensitive.
-Column names do not necessarily reflect the column names how they are in the underlying tables but rather how columns are represented (e.g. aliased) in the result.
+Both `get(Object[, Class])` methods will be remove before the release of 0.8.0.RELEASE.
 
 .Creating and Consuming a `Row` using its index
 ====

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Row.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Row.java
@@ -46,8 +46,10 @@ public interface Row {
      * @param <T>        the type of the item being returned
      * @return the value for a column in this row.  Value can be {@code null}.
      * @throws IllegalArgumentException if {@code identifier} or {@code type} is {@code null}
+     * @deprecated Use {@link #get(int, Class)} or {@link #get(String, Class)} instead
      */
     @Nullable
+    @Deprecated
     <T> T get(Object identifier, Class<T> type);
 
     /**
@@ -57,10 +59,66 @@ public interface Row {
      * @param identifier the identifier of the column.  Can be either the column index starting at 0 or column name.
      * @return the value for a column in this row.  Value can be {@code null}.
      * @throws IllegalArgumentException if {@code identifier} or {@code type} is {@code null}
+     * @deprecated Use {@link #get(int)} or {@link #get(String)} instead
      */
     @Nullable
+    @Deprecated
     default Object get(Object identifier) {
         return get(identifier, Object.class);
+    }
+
+    /**
+     * Returns the value for a column in this row.  The default implementation of this method calls {@link #get(Object, Class)} to allow SPI change in a less-breaking way.
+     *
+     * @param index the index of the column starting at 0
+     * @param type  the type of item to return.  This type must be assignable to, and allows for variance.
+     * @param <T>   the type of the item being returned.
+     * @return the value for a column in this row.  Value can be {@code null}.
+     * @throws IllegalArgumentException if {@code index} or {@code type} is {@code null}
+     */
+    @Nullable
+    default <T> T get(int index, Class<T> type) {
+        return get((Object) index, type);
+    }
+
+    /**
+     * Returns the value for a column in this row.  The default implementation of this method calls {@link #get(Object, Class)} to allow SPI change in a less-breaking way.
+     *
+     * @param name the name of the column
+     * @param type the type of item to return.  This type must be assignable to, and allows for variance.
+     * @param <T>  the type of the item being returned.
+     * @return the value for a column in this row.  Value can be {@code null}.
+     * @throws IllegalArgumentException if {@code name} or {@code type} is {@code null}
+     */
+    @Nullable
+    default <T> T get(String name, Class<T> type) {
+        return get((Object) name, type);
+    }
+
+    /**
+     * Returns the value for a column in this row using the default type mapping.  The default implementation of this method calls {@link #get(int, Class)} passing {@link Object} as the type in
+     * order to allow the implementation to make the loosest possible match.
+     *
+     * @param index the index of the column starting at 0
+     * @return the value for a column in this row.  Value can be {@code null}.
+     * @throws IllegalArgumentException if {@code index} or {@code type} is {@code null}
+     */
+    @Nullable
+    default Object get(int index) {
+        return get(index, Object.class);
+    }
+
+    /**
+     * Returns the value for a column in this row using the default type mapping.  The default implementation of this method calls {@link #get(String, Class)} passing {@link Object} as the type in
+     * order to allow the implementation to make the loosest possible match.
+     *
+     * @param name the name of the column
+     * @return the value for a column in this row.  Value can be {@code null}.
+     * @throws IllegalArgumentException if {@code name} or {@code type} is {@code null}
+     */
+    @Nullable
+    default Object get(String name) {
+        return get(name, Object.class);
     }
 
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Statement.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Statement.java
@@ -44,7 +44,9 @@ public interface Statement {
      * @return this {@link Statement}
      * @throws IllegalArgumentException  if {@code identifier} or {@code value} is {@code null}
      * @throws IndexOutOfBoundsException if the parameter index is out of range
+     * @deprecated Use {@link #bind(String, Object)} instead
      */
+    @Deprecated
     Statement bind(Object identifier, Object value);
 
     /**
@@ -57,6 +59,19 @@ public interface Statement {
      * @throws IndexOutOfBoundsException if the parameter index is out of range
      */
     Statement bind(int index, Object value);
+
+    /**
+     * Bind a value.  The default implementation of this method calls {@link #bind(Object, Object)} to allow SPI change in a less-breaking way.
+     *
+     * @param name  the name of identifier to bind to
+     * @param value the value to bind
+     * @return this {@link Statement}
+     * @throws IllegalArgumentException  if {@code name} or {@code value} is {@code null}
+     * @throws IndexOutOfBoundsException if the parameter index is out of range
+     */
+    default Statement bind(String name, Object value) {
+        return bind((Object) name, value);
+    }
 
     /**
      * Bind a value to an index.  Indexes are zero-based.
@@ -161,7 +176,9 @@ public interface Statement {
      * @param type       the type of null value
      * @return this {@link Statement}
      * @throws IllegalArgumentException if {@code identifier} or {@code type} is {@code null}
+     * @deprecated Use {@link #bindNull(String, Class)} instead
      */
+    @Deprecated
     Statement bindNull(Object identifier, Class<?> type);
 
     /**
@@ -174,6 +191,18 @@ public interface Statement {
      * @throws IndexOutOfBoundsException if the parameter index is out of range
      */
     Statement bindNull(int index, Class<?> type);
+
+    /**
+     * Bind a {@code null} value.  The default implementation of this method calls {@link #bindNull(Object, Class)} to allow SPI change in a less-breaking way.
+     *
+     * @param name the name of identifier to bind to
+     * @param type the type of null value
+     * @return this {@link Statement}
+     * @throws IllegalArgumentException if {@code name} or {@code type} is {@code null}
+     */
+    default Statement bindNull(String name, Class<?> type) {
+        return bindNull((Object) name, type);
+    }
 
     /**
      * Executes one or more SQL statements and returns the {@link Result}s.


### PR DESCRIPTION
See #76 .

Looks like int and String identifier make API more clear.

> We could include that change in a less-breaking way

Which is to add `default` implementations in `Row` and `Statement`.
