### PR TITLE
Refine parameter binding requirements.

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/compliance.adoc
+++ b/r2dbc-spec/src/main/asciidoc/compliance.adoc
@@ -31,11 +31,11 @@ The following guidelines apply to R2DBC compliance:
 
 * The specification consists of this specification document and specifications documented in each interface's Javadoc.
 
-* Drivers must support bind parameter markers.
+* Drivers supporting parametrized statements must support bind parameter markers.
+
+* Drivers supporting parametrized statements must support at least one parameter binding method (indexed or named).
 
 * Drivers must support transactions.
-
-* Drivers must support native and indexed access to column and parameter references.
 
 * Index references to columns and parameters are zero-based. The first index begins with `0`.
 

--- a/r2dbc-spec/src/main/asciidoc/statements.adoc
+++ b/r2dbc-spec/src/main/asciidoc/statements.adoc
@@ -69,6 +69,7 @@ Parameterized statements may be cached by R2DBC implementations for resuse (e.g.
 The `Statement` interface defines `bind(…)` and `bindNull(…)` methods to provide parameter values for bind marker substitution.
 The parameter type is defined by the actual value that is bound to a parameter.
 Each bind method accepts two arguments. The first is either ordinal parameter position starting at `0` (zero) or the parameter placeholder representation.
+The method of parameter binding (positional or by identifier) is vendor-specific and a driver should document its preferred binding mechanism.
 The second and any remaining parameters specify the value to be assigned to the parameter.
 
 .Binding parameters to a `Statement` object by placeholder


### PR DESCRIPTION
The way how parameters are bound is vendor-specific. To avoid requirements
of parsing SQL in the driver a driver can express its preferred approach
to bind values to parameter bind markers (indexed or named).

Drivers are no longer obliged to implement both methods but at least
one of these.

[resolves #33]