### PR TITLE
Use int and String identifier for RowMetadata

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/row-metadata.adoc
+++ b/r2dbc-spec/src/main/asciidoc/row-metadata.adoc
@@ -40,8 +40,11 @@ result.map(new BiFunction<Row, RowMetadata, Object>() {
 
 `RowMetadata` methods are used to retrieve metadata for a single or all columns.
 
-* `getColumnMetadata(…)` returns the `ColumnMetadata` by using a column identifier. The identifier is either a zero-based index or the column name, see <<compliance.guidelines>>.
+* `getColumnMetadata(int)` returns the `ColumnMetadata` by using a zero-based index, see <<compliance.guidelines>>.
+* `getColumnMetadata(String)` returns the `ColumnMetadata` by using the column name.
 * `getColumnMetadatas()` returns an unmodifiable collection of `ColumnMetadata` objects.
+
+The `getColumnMetadata(Object)` method have **deprecated** and will be remove before the release of 0.8.0.RELEASE.
 
 == Retrieving General Information for a Column
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java
@@ -35,8 +35,33 @@ public interface RowMetadata {
      * @throws IllegalArgumentException       if {@code identifier} is {@code null} or not supported
      * @throws NoSuchElementException         if there is no column with the name {@code identifier}
      * @throws ArrayIndexOutOfBoundsException if the {@code identifier} is a {@link Integer index} and it is less than zero or greater than the number of available columns.
+     * @deprecated Use {@link #getColumnMetadata(int)} or {@link #getColumnMetadata(String)} instead
      */
+    @Deprecated
     ColumnMetadata getColumnMetadata(Object identifier);
+
+    /**
+     * Returns the {@link ColumnMetadata} for one column in this row.  The default implementation of this method calls {@link #getColumnMetadata(Object)} to allow SPI change in a less-breaking way.
+     *
+     * @param index the column index starting at 0
+     * @return the {@link ColumnMetadata} for one column in this row
+     * @throws ArrayIndexOutOfBoundsException if the {@code index} is less than zero or greater than the number of available columns.
+     */
+    default ColumnMetadata getColumnMetadata(int index) {
+        return getColumnMetadata((Object) index);
+    }
+
+    /**
+     * Returns the {@link ColumnMetadata} for one column in this row.  The default implementation of this method calls {@link #getColumnMetadata(Object)} to allow SPI change in a less-breaking way.
+     *
+     * @param name the name of the column.  Column names are case insensitive.  When a get method contains several columns with same name, then the value of the first matching column will be returned
+     * @return the {@link ColumnMetadata} for one column in this row
+     * @throws IllegalArgumentException if {@code name} is {@code null}
+     * @throws NoSuchElementException   if there is no column with the {@code name}
+     */
+    default ColumnMetadata getColumnMetadata(String name) {
+        return getColumnMetadata((Object) name);
+    }
 
     /**
      * Returns the {@link ColumnMetadata} for all columns in this row.


### PR DESCRIPTION
See #76, #115 and #116 .

We should use `getColumnMetadata(int)` and `getColumnMetadata(String)` instead of `getColumnMetadata(Object)` in `RowMetadata`, just like `Row.get` and `Statement.bind*`.