### PR TITLE
Documentation edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Reactive Relational Database Connectivity Service Provider Interface (R2DBC SPI)
 
-This project contains the service provider interface for R2DBC implentations. This interface is intended to be terse to simplify implementation by database vendors and should not be used directly.  It is expected that client libraries would be built upon this interface in order to expose a more humane interface for tools and developers to use.
+This project contains the service provider interface for R2DBC implementations. This interface is intended to be terse to simplify implementation by database vendors and should not be used directly.
+It is expected that client libraries would be built upon this interface in order to expose a more humane interface for tools and developers to use.
 
 ## Maven
 Both milestone and snapshot artifacts (library, source, and javadoc) can be found in Maven repositories.
@@ -9,7 +10,7 @@ Both milestone and snapshot artifacts (library, source, and javadoc) can be foun
 <dependency>
   <groupId>io.r2dbc</groupId>
   <artifactId>r2dbc-spi</artifactId>
-  <version>1.0.0.M6</version>
+  <version>0.8.0.BUILD-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/r2dbc-spec/src/main/asciidoc/compliance.adoc
+++ b/r2dbc-spec/src/main/asciidoc/compliance.adoc
@@ -12,7 +12,7 @@ To avoid ambiguity, we will use the following terms in the compliance section an
 R2DBC driver implementation::  (short form: *driver*)A driver that implements the R2DBC SPI.
 A driver may provide support for features that are not implemented by the underlying database or expose functionality that is not declared by the R2DBC SPI (See *Extension*).
 
-Supported feature:: A feature for which the R2DBC API implementation supports standard syntax and semantics.
+Supported feature:: A feature for which the R2DBC SPI implementation supports standard syntax and semantics.
 
 Partially supported feature:: A feature for which some methods are implemented with standard syntax and semantics and some required methods are not implemented (typically covered by `default` interface methods).
 
@@ -27,7 +27,7 @@ Must implement:: Term to express that an interface must be implemented, although
 
 The following guidelines apply to R2DBC compliance:
 
-* An R2DBC API should implement SQL support as its primary interface. R2DBC does not rely upon (nor does it presume) a specific SQL version.
+* An R2DBC SPI should implement SQL support as its primary interface. R2DBC does not rely upon (nor does it presume) a specific SQL version.
 SQL and aspects of statements can be entirely handled in the data source or as part of the driver.
 
 * The specification consists of this specification document and the specifications documented in each interface's Javadoc.
@@ -42,7 +42,7 @@ SQL and aspects of statements can be entirely handled in the data source or as p
 That is, the first index begins with `0`.
 
 [[compliance.r2dbc]]
-== R2DBC API Compliance
+== R2DBC SPI Compliance
 
 A driver that is compliant with the R2DBC specification must do the following:
 

--- a/r2dbc-spec/src/main/asciidoc/connections.adoc
+++ b/r2dbc-spec/src/main/asciidoc/connections.adoc
@@ -5,7 +5,7 @@ R2DBC uses the `Connection` interface to define a logical connection API to the 
 The structure of a connection depends on the actual requirements of the data source and how the driver implements these.
 
 The data source can be an RDBMS, a stream-oriented data system, or some other source of data with a corresponding R2DBC driver.
-A single application that uses R2DBC API can maintain multiple connections to either a single data source or across multiple data sources.
+A single application that uses R2DBC SPI can maintain multiple connections to either a single data source or across multiple data sources.
 From a R2DBC driver perspective, a `Connection` object represents a single client session.
 It has associated state information, such as user ID and what transaction semantics are in effect.
 A `Connection` object is not thread-safe (it cannot be shared across multiple threads that concurrently execute statements or change its state).
@@ -99,6 +99,8 @@ public interface ConnectionFactoryProvider {
 
     boolean supports(ConnectionFactoryOptions connectionFactoryOptions);
 
+    String getDriver();
+
 }
 ----
 ====
@@ -111,9 +113,11 @@ public interface ConnectionFactoryProvider {
 `ConnectionFactoryProvider` implementations are required to return a `boolean` indicator whether or not they support a specific configuration represented by `ConnectionFactoryOptions`.
 Drivers must expect any plurality of `Option` instances to be configured.
 Drivers must report that they support a configuration only if the `ConnectionFactoryProvider` can provide a `ConnectionFactory` based on the given `ConnectionFactoryOptions`.
-Drivers should gracefully fail if a `ConnectionFactory` creation through `ConnectionFactoryProvider.create(…)` is not possible.
+A typical task handled by `supports` is checking driver and protocol options.
+Drivers should gracefully fail if a `ConnectionFactory` creation through `ConnectionFactoryProvider.create(…)` is not possible (i.e. when required options were left unconfigured).
+The `getDriver()` method reports the driver identifier that is associated with the `ConnectionFactoryProvider` implementation to provide diagnostic information to users in misconfiguration cases.
 
-See the R2DBC SPI Specification for more details.
+See the R2DBC SPI Specification and <<overview.connection.discovery,ConnectionFactory Discovery>> for more details.
 
 [[connections.factory.options]]
 == The `ConnectionFactoryOptions` Class
@@ -130,6 +134,11 @@ Options are identified by a literal.
 .Well-known Options
 |===
 |Constant |Literal |Type |Description
+
+|`SSL`
+|`ssl`
+|`java.lang.Boolean`
+|Whether the connection is configured to require SSL.
 
 |`DRIVER`
 |`driver`
@@ -160,7 +169,6 @@ Options are identified by a literal.
 |`port`
 |`java.lang.Integer`
 |Database server port number.
-
 
 |`DATABASE`
 |`database`

--- a/r2dbc-spec/src/main/asciidoc/data-types.adoc
+++ b/r2dbc-spec/src/main/asciidoc/data-types.adoc
@@ -178,7 +178,7 @@ Vendor-specific types (such as spatial data types, structured JSON or XML data, 
 [[datatypes.mapping.advanced]]
 == Mapping of Advanced Data Types
 
-The R2DBC API declares default mappings for advanced data types. The following list describes data types and the interfaces to which they map:
+The R2DBC SPI declares default mappings for advanced data types. The following list describes data types and the interfaces to which they map:
 
 * `BLOB`: The `Blob` interface
 * `CLOB`: The `Clob` interface

--- a/r2dbc-spec/src/main/asciidoc/overview.adoc
+++ b/r2dbc-spec/src/main/asciidoc/overview.adoc
@@ -4,9 +4,9 @@
 R2DBC provides an API for Java programs to access one or more sources of data.
 In the majority of cases, the data source is a relational DBMS and its data is accessed using SQL.
 R2DBC drivers are not limited to RDBMS but can be implemented on top of other data sources, including stream-oriented systems and object-oriented systems.
-A primary motivation for R2DBC API is to provide a standard API for reactive applications to integrate with a wide variety of data sources.
+A primary motivation for R2DBC SPI is to provide a standard API for reactive applications to integrate with a wide variety of data sources.
 
-This chapter gives an overview of the API and the key concepts of the R2DBC API.
+This chapter gives an overview of the API and the key concepts of the R2DBC SPI.
 It includes the following topics:
 
 * <<overview.connection>>
@@ -126,6 +126,10 @@ The following table describes the standard options:
 |===
 |Option |URL Part |Value as per Example
 
+|`ConnectionFactoryOptions.SSL`
+|`r2dbc`
+|Unconfigured.
+
 |`ConnectionFactoryOptions.DRIVER`
 |`driver`
 |`a-driver`
@@ -169,7 +173,40 @@ The following table describes the extended options:
 NOTE: R2DBC defines well-known standard options that are available as runtime constants through `ConnectionFactories`.
 Additional options identifiers are created through `Option.valueOf(…)`.
 
-[[overview.connection.usage]]
-=== Running SQL and Retrieving Results
+.Obtaining a `ConnectionFactory` using R2DBC URL
+====
+[source,java]
+----
+ConnectionFactory factory = ConnectionFactories.get("r2dbc:a-driver:pipes://localhost:3306/my_database?locale=en_US");
+----
+====
 
-TBD.
+.Obtaining a `ConnectionFactory` using `ConnectionFactoryOptions`
+====
+[source,java]
+----
+ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+    .option(ConnectionFactoryOptions.DRIVER, "a-driver")
+    .option(ConnectionFactoryOptions.PROTOCOL, "pipes")
+    .option(ConnectionFactoryOptions.HOST, "localhost")
+    .option(ConnectionFactoryOptions.PORT, 3306)
+    .option(ConnectionFactoryOptions.DATABASE, "my_database")
+    .option(Option.valueOf("locale"), "en_US")
+    .build();
+
+ConnectionFactory factory = ConnectionFactories.get(options);
+----
+====
+
+[[overview.connection.usage]]
+== Running SQL and Retrieving Results
+
+Once a connection has been established, an application using the R2DBC SPI can execute queries and updates against the connected database.
+The R2DBC SPI provides a text-based command interface to the most commonly used features of SQL databases.
+R2DBC driver implementations may expose additional functionality in a non-standard way.
+
+Applications use methods in the `Connection` interface to specify transaction attributes and create `Statement` or `Batch` objects.
+These statements are used to execute SQL and retrieve results and allow for binding values to parameter bind markers.
+The `Result` interface encapsulates the results of an SQL query.
+Statements may also be batched, allowing an application to submit multiple commands to a database as a single unit of execution.
+

--- a/r2dbc-spec/src/main/asciidoc/transactions.adoc
+++ b/r2dbc-spec/src/main/asciidoc/transactions.adoc
@@ -3,7 +3,7 @@
 
 Transactions are used to provide data integrity, isolation, correct application semantics, and a consistent view of data during concurrent database access.
 All R2DBC-compliant drivers are required to provide transaction support.
-Transaction management in the R2DBC API reflects SQL concepts:
+Transaction management in the R2DBC SPI reflects SQL concepts:
 
 * Auto-commit mode
 * Transaction isolation levels

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryProvider.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryProvider.java
@@ -16,11 +16,16 @@
 
 package io.r2dbc.spi;
 
+import java.util.ServiceLoader;
+
 /**
  * A Java Service interface for implementations to examine a collection of {@link ConnectionFactoryOptions} and optionally return an implementation of {@link ConnectionFactory}.
+ * <p>{@link ConnectionFactoryProvider} implementations are typically discovered by {@link ConnectionFactories} from the class path using {@link ServiceLoader}.
  *
  * @see ConnectionFactoryOptions
  * @see ConnectionFactory
+ * @see ConnectionFactories
+ * @see ServiceLoader
  */
 public interface ConnectionFactoryProvider {
 
@@ -47,7 +52,7 @@ public interface ConnectionFactoryProvider {
      * Returns the driver identifier used by the driver.
      * The identifier for drivers would be the value applicable to {@link ConnectionFactoryOptions#DRIVER}
      *
-     * @return The driver identifier used by the driver
+     * @return the driver identifier used by the driver
      */
     String getDriver();
 


### PR DESCRIPTION
Consistently use R2DBC SPI. Document missing `ConnectionFactoryOption`s. Add overview for `Statement`.

[resolves #77]