### PR TITLE
Remove Statement.bind(index, <primitive>) methods

### DIFF
--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Statement.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Statement.java
@@ -37,7 +37,7 @@ public interface Statement {
     Statement add();
 
     /**
-     * Bind a value to an indexed parameter.  Indexes are zero-based.
+     * Bind a non-{@code null} value to an indexed parameter.  Indexes are zero-based.
      *
      * @param index the index to bind to
      * @param value the value to bind
@@ -48,113 +48,17 @@ public interface Statement {
     Statement bind(int index, Object value);
 
     /**
-     * Bind a value to a named parameter.
+     * Bind a non-{@code null} to a named parameter.
      *
      * @param name  the name of identifier to bind to
      * @param value the value to bind
      * @return this {@link Statement}
-     * @throws IllegalArgumentException  if {@code name} or {@code value} is {@code null}
+     * @throws IllegalArgumentException if {@code name} or {@code value} is {@code null}
      */
     Statement bind(String name, Object value);
 
     /**
-     * Bind a value to an indexed parameter.  Indexes are zero-based.
-     *
-     * @param index the index to bind to
-     * @param value the value to bind
-     * @return this {@link Statement}
-     * @throws IndexOutOfBoundsException if the parameter {@code index} is out of range
-     */
-    default Statement bind(int index, boolean value) {
-        return bind(index, (Boolean) value);
-    }
-
-    /**
-     * Bind a value to an indexed parameter.  Indexes are zero-based.
-     *
-     * @param index the index to bind to
-     * @param value the value to bind
-     * @return this {@link Statement}
-     * @throws IndexOutOfBoundsException if the parameter {@code index} is out of range
-     */
-    default Statement bind(int index, byte value) {
-        return bind(index, (Byte) value);
-    }
-
-    /**
-     * Bind a value to an indexed parameter.  Indexes are zero-based.
-     *
-     * @param index the index to bind to
-     * @param value the value to bind
-     * @return this {@link Statement}
-     * @throws IndexOutOfBoundsException if the parameter {@code index} is out of range
-     */
-    default Statement bind(int index, char value) {
-        return bind(index, (Character) value);
-    }
-
-    /**
-     * Bind a value to an indexed parameter.  Indexes are zero-based.
-     *
-     * @param index the index to bind to
-     * @param value the value to bind
-     * @return this {@link Statement}
-     * @throws IndexOutOfBoundsException if the parameter {@code index} is out of range
-     */
-    default Statement bind(int index, double value) {
-        return bind(index, (Double) value);
-    }
-
-    /**
-     * Bind a value to an indexed parameter.  Indexes are zero-based.
-     *
-     * @param index the index to bind to
-     * @param value the value to bind
-     * @return this {@link Statement}
-     * @throws IndexOutOfBoundsException if the parameter index is out of range
-     */
-    default Statement bind(int index, float value) {
-        return bind(index, (Float) value);
-    }
-
-    /**
-     * Bind a value to an indexed parameter.  Indexes are zero-based.
-     *
-     * @param index the index to bind to
-     * @param value the value to bind
-     * @return this {@link Statement}
-     * @throws IndexOutOfBoundsException if the parameter {@code index} is out of range
-     */
-    default Statement bind(int index, int value) {
-        return bind(index, (Integer) value);
-    }
-
-    /**
-     * Bind a value to an indexed parameter.  Indexes are zero-based.
-     *
-     * @param index the index to bind to
-     * @param value the value to bind
-     * @return this {@link Statement}
-     * @throws IndexOutOfBoundsException if the parameter {@code index} is out of range
-     */
-    default Statement bind(int index, long value) {
-        return bind(index, (Long) value);
-    }
-
-    /**
-     * Bind a value to an indexed parameter.  Indexes are zero-based.
-     *
-     * @param index the index to bind to
-     * @param value the value to bind
-     * @return this {@link Statement}
-     * @throws IndexOutOfBoundsException if the parameter {@code index} is out of range
-     */
-    default Statement bind(int index, short value) {
-        return bind(index, (Short) value);
-    }
-
-    /**
-     * Bind a {@code null} value to an indexed parametered parameter.  Indexes are zero-based.
+     * Bind a {@code null} value to an indexed parameter.  Indexes are zero-based.
      *
      * @param index the index to bind to
      * @param type  the type of null value
@@ -186,7 +90,7 @@ public interface Statement {
      * Configures {@link Statement} to return the generated values from any rows created by this {@link Statement} in the {@link Result} returned from {@link #execute()}.  If no columns are specified,
      * implementations are free to choose which columns will be returned.  If called multiple times, only the columns requested in the final invocation will be returned.
      * <p>
-     * The default implementation of this method is a no op.
+     * The default implementation of this method is a no-op.
      *
      * @param columns the names of the columns to return
      * @return this {@code Statement}


### PR DESCRIPTION
`Statement.bind(…)` methods are now reduced to accept an `Object` value instead of multiple overloads accepting primitive values to consistently expose `bind(int/String, Object)` signatures.

Bind by index with primitives was necessary while the identifier (index or name) was represented as Object. After introducing `bind(String, …)` primitive overloads were no longer required.

[resolves #124]