### PR TITLE
Extensible transaction definition

### DIFF
--- a/r2dbc-spec/pom.xml
+++ b/r2dbc-spec/pom.xml
@@ -55,17 +55,12 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>1.5.6</version>
+                <version>2.0.0-RC.1</version>
                 <dependencies>
-                    <dependency>
+                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>1.5.0-alpha.16</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctorj-epub3</artifactId>
-                        <version>1.5.0-alpha.8.1</version>
+                        <version>1.5.3</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/r2dbc-spec/src/main/asciidoc/changes.adoc
+++ b/r2dbc-spec/src/main/asciidoc/changes.adoc
@@ -1,0 +1,17 @@
+[[changes]]
+= Overview of Changes
+
+The following section reflects the history of changes.
+
+[[changes.0.9.x]]
+== 0.9
+
+Extended transaction definitions::
+
+  Introduction of the <<transactions.transaction-definition,`TransactionDefinition`>> interface.
+  Introduction of the `Connection.beginTransaction(TransactionDefinition)` method.
+
+[[changes.0.8.x]]
+== 0.8
+
+Initial version.

--- a/r2dbc-spec/src/main/asciidoc/index.adoc
+++ b/r2dbc-spec/src/main/asciidoc/index.adoc
@@ -9,7 +9,7 @@ ifdef::backend-pdf[]
 :toc:
 endif::[]
 
-(C) 2017-2019 The original authors.
+(C) 2017-2020 The original authors.
 
 NOTE: Copies of this document may be made for your own use and for distribution to others, provided that you do not charge any fee for such copies and further provided that each copy contains this Copyright Notice, whether distributed in print or electronically.
 
@@ -20,6 +20,8 @@ include::preface.adoc[]
 include::introduction.adoc[leveloffset=+1]
 
 include::goals.adoc[leveloffset=+1]
+
+include::changes.adoc[leveloffset=+1]
 
 include::compliance.adoc[leveloffset=+1]
 

--- a/r2dbc-spec/src/main/asciidoc/license.adoc
+++ b/r2dbc-spec/src/main/asciidoc/license.adoc
@@ -11,7 +11,7 @@ Specification Lead: Pivotal Software, Inc.
 
 Release: {revdate}
 
-Copyright 2017-2019 the original author or authors.
+Copyright 2017-2020 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/r2dbc-spec/src/main/asciidoc/overview.adoc
+++ b/r2dbc-spec/src/main/asciidoc/overview.adoc
@@ -100,7 +100,6 @@ The following listing shows the syntax Components from https://www.ietf.org/rfc/
 ====
 [source,subs="none"]
 ----
-&nbsp;
 r2dbc:a-driver:pipes://localhost:3306/my_database?locale=en_US
 \___/ \______/ \___/   \____________/\__________/\___________/
   |       |      |           |           |           |

--- a/r2dbc-spec/src/main/asciidoc/transactions.adoc
+++ b/r2dbc-spec/src/main/asciidoc/transactions.adoc
@@ -5,6 +5,7 @@ Transactions are used to provide data integrity, isolation, correct application 
 All R2DBC-compliant drivers are required to provide transaction support.
 Transaction management in the R2DBC SPI reflects SQL concepts:
 
+* Transaction Boundaries
 * Auto-commit mode
 * Transaction isolation levels
 * Savepoints
@@ -14,13 +15,47 @@ This section explains transaction semantics associated with a single `Connection
 [[transactions.boundaries]]
 == Transaction Boundaries
 
-You can implicitly or explicitly start transactions.
-You can implicitly start a transaction by starting SQL execution when a `Connection` is in auto-commit mode (which is the default for newly created connections).
-When auto-commit mode is disabled, you can explicitly start a transaction by invoking the `beginTransaction()` method.
-Transactions are started by either an R2DBC driver or by the underlying database.
+Transactions begin implicitly or explicitly.
+Implicit transactions begin by starting SQL execution when a `Connection` is in auto-commit mode (which is the default for newly created connections).
+Alternatively, explicit transactions begin by invoking the `beginTransaction()` method that disables auto-commit mode.
+Transactions are started by either the R2DBC driver or its underlying database.
 
-The `Connection` attribute auto-commit mode specifies when to end transactions.
-Enabling auto-commit mode causes a transaction commit after each SQL statement as soon as that statement is completely executed.
+Newly started transactions inherit attributes from the connection such as <<transactions.isolation,Isolation Level>>. Starting a transaction using `beginTransaction(TransactionDefinition)` allows R2DBC drivers to compute a transaction definition from any plurality of attributes before starting the actual transaction. A driver may apply optimizations such as reduction of database roundtrips. Attributes retrieved from `TransactionDefinition` are only valid during the transaction.
+
+[[transactions.transaction-definition]]
+=== TransactionDefinition Interface
+
+The `io.r2dbc.spi.TransactionDefinition` interface provides a mechanism for drivers to obtain transaction attributes when starting a transaction using a vendor-neutral API. R2DBC drivers query objects implementing the interface for supported attributes. The interface defines attribute constants for commonly supported attributes such as Isolation Level, Transaction Mutability, Transaction Name, and Lock Wait Timeout. Drivers may specify and query additional attributes.
+
+[[transactions.transaction-definition.usage]]
+==== Usage
+
+Starting a transaction using a `TransactionDefinition` object allows R2DBC drivers to use the definition object as callback to query for transactional attributes.
+The following example shows how to start a transaction:
+
+.Starting a transaction using `TransactionDefinition`.
+====
+[source,java]
+----
+// connection is a Connection object
+// definition is a TransactionDefinition object
+Publisher<Void> begin = connection.beginTransaction(definition);
+----                                    
+====
+
+NOTE: Drivers may reject attributes based on the connection configuration. An example would be the use of read-write transactions with connections in read-only mode.
+
+[[transactions.transaction-definition.methods]]
+==== Interface Methods
+
+The following methods are available on the `TransactionDefinition` interface:
+
+* `getAttribute`
+
+[[transactions.transaction-definition.get-attribute]]
+==== The `getAttribute` Method
+
+R2DBC drivers invoke the `getAttribute` method to query for transaction attributes. Attributes that have no configuration value attached are considered unconfigured and therefore represented with a `null` value. The value type follows the actual attribute identified by a `Option` constant.  
 
 [[transactions.auto-commit]]
 == Auto-commit Mode

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockConnection.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockConnection.java
@@ -19,6 +19,7 @@ package io.r2dbc.spi.test;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionMetadata;
 import io.r2dbc.spi.IsolationLevel;
+import io.r2dbc.spi.TransactionDefinition;
 import io.r2dbc.spi.ValidationDepth;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
@@ -47,6 +48,8 @@ public final class MockConnection implements Connection {
 
     private String rollbackTransactionToSavepointName;
 
+    private TransactionDefinition beginTransactionDefinition;
+
     private IsolationLevel setTransactionIsolationLevelIsolationLevel;
 
     private boolean valid;
@@ -72,6 +75,13 @@ public final class MockConnection implements Connection {
     @Override
     public Mono<Void> beginTransaction() {
         this.beginTransactionCalled = true;
+        return Mono.empty();
+    }
+
+    @Override
+    public Publisher<Void> beginTransaction(TransactionDefinition definition) {
+        this.beginTransactionCalled = true;
+        this.beginTransactionDefinition = definition;
         return Mono.empty();
     }
 
@@ -137,6 +147,10 @@ public final class MockConnection implements Connection {
     @Override
     public ConnectionMetadata getMetadata() {
         return MockConnectionMetadata.INSTANCE;
+    }
+
+    public TransactionDefinition getBeginTransactionDefinition() {
+        return this.beginTransactionDefinition;
     }
 
     @Nullable

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Connection.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Connection.java
@@ -45,6 +45,15 @@ public interface Connection extends Closeable {
     Publisher<Void> beginTransaction();
 
     /**
+     * Begins a new transaction.  Calling this method disables {@link #isAutoCommit() auto-commit} mode.
+     *
+     * @param definition attributes for the transaction.
+     * @return a {@link Publisher} that indicates that the transaction is open
+     * @since 0.9
+     */
+    Publisher<Void> beginTransaction(TransactionDefinition definition);
+
+    /**
      * Release any resources held by the {@link Connection}.
      *
      * @return a {@link Publisher} that termination is complete

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Connection.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Connection.java
@@ -45,7 +45,8 @@ public interface Connection extends Closeable {
     Publisher<Void> beginTransaction();
 
     /**
-     * Begins a new transaction.  Calling this method disables {@link #isAutoCommit() auto-commit} mode.
+     * Begins a new transaction.  Calling this method disables {@link #isAutoCommit() auto-commit} mode.  Beginning the transaction may fail if the {@link TransactionDefinition} conflicts with the
+     * connection configuration.
      *
      * @param definition attributes for the transaction.
      * @return a {@link Publisher} that indicates that the transaction is open

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
@@ -45,6 +45,8 @@ import java.util.function.Predicate;
  *     .option(Option.valueOf("locale"), "en_US")
  *     .build();
  * </pre>
+ * <p>
+ * Note that Connection URL Parsing cannot access {@link Option} type information {@code T} due to Java's type erasure. Options configured by URL parsing are represented as {@link String} values.
  *
  * @see ConnectionFactories
  */

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/IsolationLevel.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/IsolationLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package io.r2dbc.spi;
 /**
  * Represents a transaction isolation level constant.
  */
-public final class IsolationLevel {
+public final class IsolationLevel implements TransactionDefinition {
 
     private static final ConstantPool<IsolationLevel> CONSTANTS = new ConstantPool<IsolationLevel>() {
 
@@ -68,6 +68,18 @@ public final class IsolationLevel {
         Assert.requireNonEmpty(sql, "sql must not be empty");
 
         return CONSTANTS.valueOf(sql, false);
+    }
+
+    @Override
+    public <T> T getAttribute(String name, Class<T> type) {
+        Assert.requireNonNull(name, "sql must not be null");
+        Assert.requireNonNull(type, "type must not be null");
+
+        if (name.equals(ISOLATION_LEVEL)) {
+            return type.cast(this);
+        }
+
+        return null;
     }
 
     /**

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/IsolationLevel.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/IsolationLevel.java
@@ -71,12 +71,11 @@ public final class IsolationLevel implements TransactionDefinition {
     }
 
     @Override
-    public <T> T getAttribute(String name, Class<T> type) {
-        Assert.requireNonNull(name, "sql must not be null");
-        Assert.requireNonNull(type, "type must not be null");
+    public <T> T getAttribute(Option<T> option) {
+        Assert.requireNonNull(option, "option must not be null");
 
-        if (name.equals(ISOLATION_LEVEL)) {
-            return type.cast(this);
+        if (option.equals(TransactionDefinition.ISOLATION_LEVEL)) {
+            return option.cast(this);
         }
 
         return null;

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Option.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Option.java
@@ -20,11 +20,10 @@ import java.util.Objects;
 
 /**
  * Represents a configuration option constant.
- * <p>
- * Note that Connection URL Parsing cannot access {@link Option} type information {@code T} due to Java's type erasure. Options configured by URL parsing are represented as {@link String} values.
  *
  * @param <T> The value type of the option when configuring a value programmatically
  * @see ConnectionFactoryOptions
+ * @see TransactionDefinition
  */
 public final class Option<T> {
 
@@ -76,6 +75,24 @@ public final class Option<T> {
         Assert.requireNonEmpty(name, "name must not be empty");
 
         return (Option<T>) CONSTANTS.valueOf(name, false);
+    }
+
+    /**
+     * Casts an object to the class or interface represented by this option object.
+     *
+     * @param obj the object to be cast
+     * @return the object after casting, or null if obj is {@code null}.
+     * @since 0.9
+     */
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public T cast(@Nullable Object obj) {
+
+        if (obj == null) {
+            return null;
+        }
+
+        return (T) obj;
     }
 
     /**

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/TransactionDefinition.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/TransactionDefinition.java
@@ -16,57 +16,47 @@
 
 package io.r2dbc.spi;
 
+import java.time.Duration;
+
 /**
- * Specification of properties to be used when starting a transaction
+ * Specification of properties to be used when starting a transaction.  This interface is typically implemented by code that calls {@link Connection#beginTransaction(TransactionDefinition)}.
  *
  * @see Connection#beginTransaction(TransactionDefinition)
+ * @see Option
  * @since 0.9
  */
 public interface TransactionDefinition {
 
-    /**
-     * Name of the isolation level transaction attribute.
+    /*
+     * Isolation level requested for the transaction.
      */
-    String ISOLATION_LEVEL = "IsolationLevel";
+    Option<IsolationLevel> ISOLATION_LEVEL = Option.valueOf("isolationLevel");
 
     /**
-     * Name of the read only transaction attribute.
+     * The transaction mutability (i.e. whether the transaction should be started in read-only mode).
      */
-    String READ_ONLY = "ReadOnly";
+    Option<Boolean> READ_ONLY = Option.valueOf("readOnly");
 
     /**
-     * Configures the isolation level for the transaction to start.
+     * Name of the transaction.
+     */
+    Option<String> NAME = Option.valueOf("name");
+
+    /**
+     * Lock wait timeout.
+     */
+    Option<Duration> LOCK_WAIT_TIMEOUT = Option.valueOf("lockWaitTimeout");
+
+    /**
+     * Retrieve a transaction attribute by its {@link Option} identifier.  This low-level interface allows querying transaction attributes supported by the {@link Connection} that should be applied
+     * when starting a new transaction.
      *
-     * @return the {@link IsolationLevel} to use. Can be {@code null} to indicate that the current isolation level should be used.
-     */
-    @Nullable
-    default IsolationLevel getIsolationLevel() {
-        return getAttribute(ISOLATION_LEVEL, IsolationLevel.class);
-    }
-
-    /**
-     * Returns whether the transaction should be a read-only one or read-write by returning {@code true} respective {@code false}.
-     *
-     * @return {@code true} to specify a read-only transaction; {@code false} for a read-write transaction. Can be {@code null} to indicate that the current transaction mutability should be used.
-     */
-    @Nullable
-    default Boolean isReadOnly() {
-        return getAttribute(READ_ONLY, Boolean.class);
-    }
-
-    /**
-     * Retrieve a transaction attribute by its name.  This low-level interface allows querying transaction attributes supported by the {@link Connection} that should be applied when starting a new
-     * transaction.  The {@link Class type} parameter can be used to request a specific value type for easier consumption.  If a value cannot be represented as the requested type, then a
-     * {@link ClassCastException} is thrown.
-     *
-     * @param name the name of the transaction attribute
-     * @param type requested type of the attribute
-     * @param <T>  requested value type
+     * @param option the option to retrieve the value for
+     * @param <T>    requested value type
      * @return the value of the transaction attribute. Can be {@code null} to indicate absence of the attribute.
      * @throws IllegalArgumentException if {@code name} or {@code type} is {@code null}
-     * @throws ClassCastException       if the value cannot be assigned to {@code type}
      */
     @Nullable
-    <T> T getAttribute(String name, Class<T> type);
+    <T> T getAttribute(Option<T> option);
 
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/TransactionDefinition.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/TransactionDefinition.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+/**
+ * Specification of properties to be used when starting a transaction
+ *
+ * @see Connection#beginTransaction(TransactionDefinition)
+ * @since 0.9
+ */
+public interface TransactionDefinition {
+
+    /**
+     * Name of the isolation level transaction attribute.
+     */
+    String ISOLATION_LEVEL = "IsolationLevel";
+
+    /**
+     * Name of the read only transaction attribute.
+     */
+    String READ_ONLY = "ReadOnly";
+
+    /**
+     * Configures the isolation level for the transaction to start.
+     *
+     * @return the {@link IsolationLevel} to use. Can be {@code null} to indicate that the current isolation level should be used.
+     */
+    @Nullable
+    default IsolationLevel getIsolationLevel() {
+        return getAttribute(ISOLATION_LEVEL, IsolationLevel.class);
+    }
+
+    /**
+     * Returns whether the transaction should be a read-only one or read-write by returning {@code true} respective {@code false}.
+     *
+     * @return {@code true} to specify a read-only transaction; {@code false} for a read-write transaction. Can be {@code null} to indicate that the current transaction mutability should be used.
+     */
+    @Nullable
+    default Boolean isReadOnly() {
+        return getAttribute(READ_ONLY, Boolean.class);
+    }
+
+    /**
+     * Retrieve a transaction attribute by its name.  This low-level interface allows querying transaction attributes supported by the {@link Connection} that should be applied when starting a new
+     * transaction.  The {@link Class type} parameter can be used to request a specific value type for easier consumption.  If a value cannot be represented as the requested type, then a
+     * {@link ClassCastException} is thrown.
+     *
+     * @param name the name of the transaction attribute
+     * @param type requested type of the attribute
+     * @param <T>  requested value type
+     * @return the value of the transaction attribute. Can be {@code null} to indicate absence of the attribute.
+     * @throws IllegalArgumentException if {@code name} or {@code type} is {@code null}
+     * @throws ClassCastException       if the value cannot be assigned to {@code type}
+     */
+    @Nullable
+    <T> T getAttribute(String name, Class<T> type);
+
+}


### PR DESCRIPTION
We now expose a `Connection.beginTransaction` method accepting a `TransactionDefinition` that can report various transaction attributes. Drivers can choose to provide a vendor-specific extension to specify attributes that apply to their database.

Transaction attributes are optional and expected to be set when starting a transaction when one or more attribute is configured. The callback mechanism allows for a simplified extension model so a library can provide a generic `TransactionDefinition` implementation that is configured with attributes required for a database without the need to depend on vendor-specific classes.

--- 

Todo:

- [x] Discuss the proposal
- [x] Documentation