### PR TITLE
WIP: introduce createSimpleStatement() & createPreparedStatement()

### DIFF
--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockConnection.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockConnection.java
@@ -103,7 +103,19 @@ public final class MockConnection implements Connection {
     }
 
     @Override
-    public MockStatement createStatement(String sql) {
+    public MockStatement createSimpleStatement(String sql) {
+        Assert.requireNonNull(sql, "sql must not be null");
+
+        if (this.statement == null) {
+            throw new AssertionError("Unexpected call to createStatement(String)");
+        }
+
+        this.createStatementSql = sql;
+        return this.statement;
+    }
+
+    @Override
+    public MockStatement createPreparedStatement(String sql) {
         Assert.requireNonNull(sql, "sql must not be null");
 
         if (this.statement == null) {

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Connection.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Connection.java
@@ -77,13 +77,22 @@ public interface Connection extends Closeable {
     Publisher<Void> createSavepoint(String name);
 
     /**
-     * Creates a new statement for building a statement-based request.
+     * Creates a new simple statement for building a statement-based request.
      *
      * @param sql the SQL of the statement
      * @return a new {@link Statement} instance
      * @throws IllegalArgumentException if {@code sql} is {@code null}
      */
-    Statement createStatement(String sql);
+    Statement createSimpleStatement(String sql);
+
+    /**
+     * Creates a new prepared statement for building a statement-based request.
+     *
+     * @param sql the SQL of the statement
+     * @return a new {@link Statement} instance
+     * @throws IllegalArgumentException if {@code sql} is {@code null}
+     */
+    Statement createPreparedStatement(String sql);
 
     /**
      * Returns the auto-commit mode for this connection.


### PR DESCRIPTION
#### Issue description
From https://github.com/pgjdbc/r2dbc-postgresql/issues/312.

There are problems and difficulties with parsing query approach in order to determine which query is: SimpleQuery or ExtendedQuery (Prepared Statement).

> I think to avoid any parsing and make explicit API like in JDBC (connection.extendedStatement(), connection.simpleStatement()). So application developer will must explicitly type what he or she wants.

 
#### New Public APIs
```
io.r2dbc.spi.Connection#createSimpleStatement
io.r2dbc.spi.Connection#createPreparedStatement
```

Drawbacks are that we need change all drivers, but this change doesn't looks very complex.

In particular this change will lead to remove ExtendedQueryPostgresqlStatement#supports and SimpleQueryPostgresqlStatement#supports.

It is draft, so I can be wrong and maybe we can tackle https://github.com/pgjdbc/r2dbc-postgresql/issues/312 with query parsing as @toverdijk suggested.