### PR TITLE
 gh-issue-183-to avoid problems when authority strings contains special characters …

### DIFF
--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionUrlParser.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionUrlParser.java
@@ -121,7 +121,8 @@ abstract class ConnectionUrlParser {
 
             if (authorityToUse.contains("@")) {
 
-                int atIndex = authorityToUse.indexOf('@');
+                // to avoid problems when authority strings contains special characters like '@'
+                int atIndex = authorityToUse.lastIndexOf('@');
                 String userinfo = authorityToUse.substring(0, atIndex);
                 authorityToUse = authorityToUse.substring(atIndex + 1);
 


### PR DESCRIPTION
to avoid problems when authority strings contain special characters like '@'
