### PR TITLE
Add Wrapped#unwrap(Class) method

### DIFF
--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Wrapped.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Wrapped.java
@@ -30,4 +30,31 @@ public interface Wrapped<T> {
      */
     T unwrap();
 
+    /**
+     * Recursively {@link #unwrap()} the object and returns the first instance that
+     * matches to the given {@link Class} or {@code null} if none matches.
+     * <p>
+     * If this object is an instance of the given {@link Class}, this object is returned.
+     *
+     * @param targetClass target type to unwrap
+     * @param <E>         returning type
+     * @return unwrapped instance of given type or {@code null}
+     * @throws IllegalArgumentException if {@code targetClass} is {@code null}
+     * @since 0.9.0
+     */
+    @Nullable
+    @SuppressWarnings("unchecked")
+    default <E> E unwrap(Class<E> targetClass) {
+        Assert.requireNonNull(targetClass, "targetClass must not be null");
+
+        if (targetClass.isInstance(this)) {
+            return (E) this;
+        }
+        T unwrapped = this.unwrap();
+        if (!(unwrapped instanceof Wrapped)) {
+            return null;
+        }
+        return ((Wrapped<?>) unwrapped).unwrap(targetClass);
+    }
+
 }

--- a/r2dbc-spi/src/test/java/io/r2dbc/spi/WrappedUnitTests.java
+++ b/r2dbc-spi/src/test/java/io/r2dbc/spi/WrappedUnitTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link Wrapped}.
+ */
+class WrappedUnitTests {
+
+    @Test
+    void unwrap() {
+        Person person = new Person() {
+
+        };
+
+        Foo foo = new Foo(person);
+        Bar bar = new Bar(foo);
+        Baz baz = new Baz(bar);
+
+        assertThat(baz.unwrap(Foo.class)).isSameAs(foo);
+        assertThat(baz.unwrap(Bar.class)).isSameAs(bar);
+        assertThat(baz.unwrap(Baz.class)).isSameAs(baz);
+
+        assertThat(foo.unwrap(Foo.class)).isSameAs(foo);
+        assertThat(foo.unwrap(Bar.class)).isNull();
+
+        // unwrap to the outer most class
+        assertThat(foo.unwrap(Person.class)).isSameAs(foo);
+        assertThat(bar.unwrap(Person.class)).isSameAs(bar);
+        assertThat(baz.unwrap(Person.class)).isSameAs(baz);
+
+        assertThat(foo.unwrap(String.class)).isNull();
+        assertThat(bar.unwrap(String.class)).isNull();
+        assertThat(baz.unwrap(String.class)).isNull();
+    }
+
+    interface Person {
+
+    }
+
+    static abstract class AbstractPerson implements Person, Wrapped<Person> {
+
+        Person person;
+
+        public AbstractPerson(Person person) {
+            this.person = person;
+        }
+
+        @Override
+        public Person unwrap() {
+            return this.person;
+        }
+
+    }
+
+    static class Foo extends AbstractPerson implements Person {
+
+        public Foo(Person person) {
+            super(person);
+        }
+    }
+
+    static class Bar extends AbstractPerson {
+
+        public Bar(Person person) {
+            super(person);
+        }
+    }
+
+    static class Baz extends AbstractPerson {
+
+        public Baz(Person person) {
+            super(person);
+        }
+    }
+
+}


### PR DESCRIPTION
#### Issue description

Add a default method `Wrapped#unwrap(Class)` which recursively unwrap the nested Wrapped object and returns the first matched object that is an instance of the given class. [#176]

 
#### New Public APIs

- `Wrapped#unwrap(Class)`

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
