### PR TITLE
Allow configuring auto-commit mode through properties

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/transactions.adoc
+++ b/r2dbc-spec/src/main/asciidoc/transactions.adoc
@@ -25,7 +25,7 @@ Enabling auto-commit mode causes a transaction commit after each SQL statement a
 [[transactions.auto-commit]]
 == Auto-commit Mode
 
-A `ConnectionFactory` creates new `Connection` objects with auto-commit mode enabled.
+A `ConnectionFactory` creates new `Connection` objects with auto-commit mode enabled, unless specified otherwise through connection configuration options.
 The `Connection` interface provides two methods to interact with auto-commit mode:
 
 * `setAutoCommit`


### PR DESCRIPTION
By default, R2DBC connections are created in auto-commit mode. We'd like to allow users to pass `autocommit=false` property in Cloud Spanner R2DBC driver for consistency with the existing JDBC driver.

This change relaxes the specification to allow the default auto-commit state to be configured through connection configuration properties.