### PR TITLE
[#27] Offer result type agnostic mapping to Result

### DIFF
--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Result.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Result.java
@@ -17,8 +17,11 @@
 package io.r2dbc.spi;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Represents the results of a query against a database.  Results can be consumed only once by either consuming {@link #getRowsUpdated()} or {@link #map(BiFunction)}.
@@ -30,12 +33,55 @@ import java.util.function.BiFunction;
 public interface Result {
 
     /**
+     * A mapping function container that is used to map interleaved result types of unknown order.
+     *
+     * <p>Databases may produce interleaved update counts or result sets without explicit knowledge of order by clients.</p>
+     */
+    interface Mapping<T> {
+
+        /**
+         * The function translating update counts to a custom type.
+         *
+         * @see #getRowsUpdated()
+         */
+        Function<Integer, ? extends Publisher<T>> rowsUpdated();
+
+        /**
+         * The function translating rows to a custom type.
+         *
+         * @see #map(BiFunction)
+         */
+        BiFunction<Row, RowMetadata, ? extends Publisher<T>> rowsFetched();
+    }
+
+    /**
+     * Returns the number of rows updated by a query or a mapping of the rows that are the results of a query against a database. May be empty.
+     *
+     * @param mapping The mapping function container holding implementations of {@link #getRowsUpdated()} and {@link #map(BiFunction)}.
+     * @throws IllegalArgumentException if {@code mapping} is {@code null}
+     * @throws IllegalStateException if the result was consumed
+     */
+    <T> Publisher<T> map(Mapping<T> mapping);
+
+    /**
      * Returns the number of rows updated by a query against a database.  May be empty if the query did not update any rows.
      *
      * @return the number of rows updated by a query against a database
      * @throws IllegalStateException if the result was consumed
      */
-    Publisher<Integer> getRowsUpdated();
+    default Publisher<Integer> getRowsUpdated() {
+        return map(new Mapping<Integer>() {
+            @Override
+            public Function<Integer, Publisher<Integer>> rowsUpdated() {
+                return SingleValuePublisher::new;
+            }
+
+            @Override
+            public BiFunction<Row, RowMetadata, Publisher<Integer>> rowsFetched() {
+                return (r, m) -> new EmptyPublisher<>();
+            }
+        });
+    }
 
     /**
      * Returns a mapping of the rows that are the results of a query against a database.  May be empty if the query did not return any rows.  A {@link Row} can be only considered valid within a
@@ -47,6 +93,55 @@ public interface Result {
      * @throws IllegalArgumentException if {@code mappingFunction} is {@code null}
      * @throws IllegalStateException    if the result was consumed
      */
-    <T> Publisher<T> map(BiFunction<Row, RowMetadata, ? extends T> mappingFunction);
+    default <T> Publisher<T> map(BiFunction<Row, RowMetadata, ? extends T> mappingFunction) {
+        return map(new Mapping<T>() {
+            @Override
+            public Function<Integer, ? extends Publisher<T>> rowsUpdated() {
+                return i -> new EmptyPublisher<>();
+            }
 
+            @Override
+            public BiFunction<Row, RowMetadata, ? extends Publisher<T>> rowsFetched() {
+                return (r, m) -> new SingleValuePublisher<>(mappingFunction.apply(r, m));
+            }
+        });
+    }
+}
+
+final class SingleValuePublisher<T> implements Publisher<T> {
+    private final T t;
+
+    SingleValuePublisher(T t) {
+        this.t = t;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> s) {
+        s.onSubscribe(new Subscription() {
+            @Override
+            public void request(long n) {
+                s.onNext(t);
+                s.onComplete();
+            }
+
+            @Override
+            public void cancel() {}
+        });
+    }
+}
+
+final class EmptyPublisher<T> implements Publisher<T> {
+
+    @Override
+    public void subscribe(Subscriber<? super T> s) {
+        s.onSubscribe(new Subscription() {
+            @Override
+            public void request(long n) {
+                s.onComplete();
+            }
+
+            @Override
+            public void cancel() {}
+        });
+    }
 }


### PR DESCRIPTION
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/main/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/main/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

#### Issue description

As discussed in https://github.com/r2dbc/r2dbc-spi/issues/27#issuecomment-811127450

Clients may not know in advance whether a Result contains update counts or row data. The current SPI design does not allow for checking the Result for its contents, nor for trying out both possibilities and reverting to the other if one fails.

This suggestion offers a solution to this problem:

- A new `Mapping<T>` type is added containing functions for the individual mappings. This type is important for forwards compatibility, such that additional types of results (e.g. out parameters or signals, exceptions, warnings) can be added later
- The new `Mapping<T>` allows for mapping between 1 element (update count, row) to 0-N elements via a `Publisher<T>`. This is useful to allow for skipping values directly on the individual Result level
- A new `map(Mapping<T>)` method is added as a breaking change
- Default implementations delegating to the new methods are added for the existing methods

Signed-off-by: Lukas Eder <lukas.eder@gmail.com>
 
#### New Public APIs

- `Result.Mapping`
- `Result.map(Mapping)` (breaking change for drivers, no breaking changes introduced for consumers)