### PR TITLE
Add support for `OutParameters`

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/data-types.adoc
+++ b/r2dbc-spec/src/main/asciidoc/data-types.adoc
@@ -223,18 +223,18 @@ statement.bind("text", clob);
 ====
 
 [[datatypes.lob.retrieve]]
-=== Retrieving `Blob` and `Clob` Objects from a `Row`
+=== Retrieving `Blob` and `Clob` Objects from a `Readable`
 
 The Binary Large OBject (`BLOB`) and Character Large OBject (`CLOB`) data types are treated similarly to primitive built-in types.
-You can retrieve values of these types by calling the `get(…)` methods on the `Row` interface.
+You can retrieve values of these types by calling the `get(…)` methods on the `Readable` interface.
 The following example shows how to do so:
 
 .Retrieving a `Clob` object
 ====
 [source,java]
 ----
-// result is a Row object
-Publisher<Clob> clob = result.map((row, rowMetadata) -> row.get("clob", Clob.class));
+// result is a Result object
+Publisher<Clob> clob = result.map((readable) -> readable.get("clob", Clob.class));
 ----
 ====
 
@@ -250,8 +250,7 @@ The actual default data type for LOB data types can be vendor-specific to avoid 
 The `Blob` and `Clob` interfaces declare methods to consume the content of each type.
 Content streams follow Reactive Streams specifications and reflect the stream nature of large objects.
 As a result, `Blob` and `Clob` objects can be consumed only once.
-Large object data consumption can be canceled by calling the `discard()` method if the content stream was not consumed at all.
-Alternatively, if the content stream was consumed, a `Subscription` cancellation releases resources that are associated with the large object.
+Large object data consumption can be canceled by calling the `discard()` method if the content stream was not consumed at all.Alternatively, if the content stream was consumed, a `Subscription` cancellation releases resources that are associated with the large object.
 
 The following example shows how to consume `Clob` contents:
 

--- a/r2dbc-spec/src/main/asciidoc/index.adoc
+++ b/r2dbc-spec/src/main/asciidoc/index.adoc
@@ -37,7 +37,13 @@ include::batches.adoc[leveloffset=+1]
 
 include::result.adoc[leveloffset=+1]
 
+include::rows.adoc[leveloffset=+1]
+
+include::out-parameters.adoc[leveloffset=+1]
+
 include::row-metadata.adoc[leveloffset=+1]
+
+include::out-parameter-metadata.adoc[leveloffset=+1]
 
 include::exceptions.adoc[leveloffset=+1]
 

--- a/r2dbc-spec/src/main/asciidoc/out-parameter-metadata.adoc
+++ b/r2dbc-spec/src/main/asciidoc/out-parameter-metadata.adoc
@@ -1,0 +1,81 @@
+[[out-parameter-metadata]]
+= OUT Parameter Metadata
+
+The `OutParametersMetadata` interface is implemented by R2DBC drivers to provide information about OUT parameters.
+It is used primarily by libraries and applications to determine the properties of result parameters.
+
+In cases where the result properties of an SQL statement are unknown until it is run, the `OutParametersMetadata` can be used to determine the actual properties.
+
+`OutParametersMetadata` exposes `OutParameterMetadata` for each returned out parameter.
+Drivers should provide `OutParameterMetadata` on a best-effort basis.
+Out parameter metadata is typically a by-product of stored procedure execution.
+The amount of available information is vendor-dependent.
+Metadata retrieval can require additional lookups (internal queries) to provide a complete metadata descriptor.
+Issuing queries during result processing conflicts with the streaming nature of R2DBC.
+Consequently, `OutParameterMetadata` declares two sets of methods: methods that must be implemented and methods that can optionally be implemented by drivers.
+
+== Obtaining a `OutParametersMetadata` Object
+
+A `OutParametersMetadata` object is created during results consumption through `Result.map(…)`.
+It is created once for all out parameters.
+The following example illustrates retrieval and usage by using an anonymous inner class:
+
+.Using `OutParametersMetadata` and retrieving `OutParameterMetadata`
+====
+[source,java]
+----
+// result is a Result object
+result.map(new Function<Readable, Object>() {
+
+    @Override
+    public Object apply(Readable readable) {
+
+        if (readable instanceof OutParameters) {
+
+            OutParameters out = (OutParameters) readable;
+            OutParametersMetadata md = out.getMetadata();
+
+            OutParameterMetadata my_parameter = md.getParameterMetadata("my_parameter");
+            Nullability nullability = my_parameter.getNullability();
+            // …
+        }
+    }
+});
+----
+====
+
+[[outparametermetadata]]
+== Retrieving `OutParameterMetadata`
+
+`OutParameterMetadata` methods are used to retrieve metadata for a single parameter or all parameters.
+
+* `getParameterMetadata(int)` returns the `OutParameterMetadata` by using a zero-based index.
+See <<compliance.guidelines>>.
+* `getParameterMetadata(String)` returns the `OutParameterMetadata` by using the parameter name.
+* `getParameterMetadatas()` returns an unmodifiable collection of `OutParameterMetadata` objects.
+
+== Retrieving General Information for a OUT Parameter
+
+`OutParameterMetadata` declares methods to access out parameter metadata on a best-effort basis.
+Out parameter metadata that is available as a by-product of running a statement must be made available through `OutParameterMetadata`.
+Metadata exposure requiring interaction with the database (for example, issuing queries to information schema entities to resolve type properties) cannot be exposed, because methods on `OutParameterMetadata` are expected to be non-blocking.
+
+NOTE: Implementation note: Drivers can use metadata from a static mapping or obtain metadata indexes on connection creation.
+
+The following example shows how to consume `OutParameterMetadata` by using lambdas:
+
+.Retrieving `OutParameterMetadata` information
+====
+[source,java]
+----
+// out is a OutParametersMetadata object
+out.getParameterMetadatas().forEach(outParameterMetadata -> {
+
+    String name = outParameterMetadata.getName();
+    Integer precision = outParameterMetadata.getPrecision();
+    Integer scale = outParameterMetadata.getScale();
+});
+----
+====
+
+See the API specification for more details.

--- a/r2dbc-spec/src/main/asciidoc/out-parameters.adoc
+++ b/r2dbc-spec/src/main/asciidoc/out-parameters.adoc
@@ -1,0 +1,86 @@
+[[out-parameters]]
+== OUT Parameters
+
+A `OutParameters` object represents a set of `OUT` parameters as result of a stored procedure/server-side function invocation.
+
+[[out-parameters.values]]
+=== Retrieving Values
+
+The `Result` interface provides a `map(…)` method for retrieving values from `Readable` objects.
+The `map` method accepts a `Function` (also referred to as mapping function) for `Readable` which can be an implementation of `OutParameters` or `Row` objects or vendor-specific extensions.
+The mapping function is called upon emission with `Readable` objects.
+A `Readable` is only valid during the mapping function callback and is invalid outside of the mapping function callback.
+Thus, `Readable` objects must be entirely consumed by the mapping function.
+
+The <<out-parameter-metadata>> section contains additional details on metadata.
+
+[[out-parameters.methods]]
+== Interface Methods
+
+The following methods are available on the `OutParameters` interface:
+
+* `Object get(int)` (inherited from `Readable`)
+* `Object get(String)` (inherited from `Readable`)
+* `<T> T get(int, Class<T>)` (inherited from `Readable`)
+* `<T> T get(String, Class<T>)` (inherited from `Readable`)
+* `OutParametersMetadata getMetadata()`
+
+`get(int[, Class])` methods accept parameter indexes starting at `0`, `get(String[, Class])` methods accept parameter names as they are represented in the result.
+Parameter names used as input to the `get` methods are case-insensitive.
+The following example shows how to create and consume `OutParameters` by using its index:
+
+.Creating and Consuming `OutParameters` by obtaining a parameter by index
+====
+[source,java]
+----
+// result is a Result object
+Publisher<Object> values = result.map((readable) -> readable.get(0));
+----
+====
+
+The following example shows how to create and consume `OutParameters` by using a parameter name:
+
+.Creating and Consuming a `OutParameters` by obtaining a parameter by name
+====
+[source,java]
+----
+// result is a Result object
+Publisher<Object> titles = result.map((readable) -> readable.get("title"));
+----
+====
+
+Calling `get` without specifying a target type returns a suitable value representation according to <<datatypes.mapping>>.
+When specifying a target type, the R2DBC driver tries to convert the value to the target type.
+The following example shows how to create and consume `OutParameters` with type conversion:
+
+.Creating and Consuming `OutParameters` with type conversion
+====
+[source,java]
+----
+// result is a Result object
+Publisher<String> values = result.map((readable) -> readable.get(0, String.class));
+----
+====
+
+You can consume multiple parameters from `OutParameters`, as the following example shows:
+
+.Consuming multiple parameters from `OutParameters`
+====
+[source,java]
+----
+// result is a Result object
+Publisher<Book> values = result.map((readable) -> {
+    String title = readable.get("title", String.class);
+    String author = readable.get("author", String.class);
+
+    return new Book(title, author);
+});
+----
+====
+
+When the parameter value in the database is SQL `NULL`, it can be returned to the Java application as `null`.
+
+NOTE: `null` values cannot be returned as Reactive Streams values and must be wrapped for subsequent usage.
+
+NOTE: Invalidating `OutParameters` does *not* release `Blob` and `Clob` objects that were obtained from `OutParameters`.
+These objects remain valid for at least the duration of the transaction in which they were created, unless their `discard()` method is called.

--- a/r2dbc-spec/src/main/asciidoc/result.adoc
+++ b/r2dbc-spec/src/main/asciidoc/result.adoc
@@ -1,18 +1,22 @@
 [[results]]
 = Results
 
-This section explains the `Result` interface and the related `Row` interface. It also describes related topics, including result consumption.
+This section explains the `Result` interface and the related `Readable` interface.
+It also describes related topics, including result consumption.
 
 [[results.characteristics]]
 == Result Characteristics
 
-`Result` objects are forward-only and read-only objects that allow consumption of two result types:
+`Result` objects are forward-only and read-only objects that allow consumption of the following result types:
 
-* Tabular results
 * Update count
+* <<rows,Tabular results>>
+* <<out-parameters,OUT parameters>>
 
-Results move forward from the first `Row` to the last one. After emitting the last row, a `Result` object gets invalidated and rows from the same `Result` object can no longer be consumed.
-Rows contained in the result depend on how the underlying database materializes the results.
+Results move forward from the first `Row` to the last one.
+After emitting the last row, drivers can expose out parameters by emitting `OutParameters`.
+After that, a `Result` object gets invalidated and results from the same `Result` object can no longer be consumed.
+Rows and parameters contained in the result depend on how the underlying database materializes the results.
 That is, it contains the rows that satisfy the query at either the time the query is run or as the rows are retrieved.
 An R2DBC driver can obtain a `Result` either directly or by using cursors.
 
@@ -30,18 +34,20 @@ Publisher<Integer> rowsUpdated = result.getRowsUpdated();
 ----
 ====
 
-The streaming nature of a result allows consumption of either tabular results or an update count.
+`Result` represens a stream of result segements.
+Due to its nature, a result allows consumption of either tabular results, out parameters, or an update count through `map(…)` respective `getRowsUpdated(…)` but not both.
 Depending on how the underlying database materializes results, an R2DBC driver can lift this limitation.
 
 A `Result` object is emitted for each statement result in a forward-only direction.
+A statement can lead to multiple `Result` objects caused by either multiple bindings or by running a statement that materializes multiple result sets.
 
 <<<
 
 [[results.creating]]
 == Creating `Result` Objects
 
-A `Result` object is most often created as the result of running a `Statement` object.
-The `Statement.execute()` method returns a `Publisher` that emits a `Result` objects as the result of running the statement.
+A `Result` object is created as the result of running a `Statement` object.
+The `Statement.execute()` method returns a `Publisher` that emits `Result` objects as the result of running the statement.
 The following example shows how to create a `Result` object:
 
 .Creating a `Result` object
@@ -67,89 +73,3 @@ Thus, external cursor navigation is not possible.
 Canceling subscription of tabular results stops cursor reads and releases any resources associated with the `Result` object.
 
 <<<
-
-[[rows]]
-== Rows
-
-A `Row` object represents a single row of tabular results.
-
-[[row.values]]
-=== Retrieving Values
-
-The `Result` interface provides a `map(…)` method for retrieving values from `Row` objects.
-The `map` method accepts a `BiFunction` (also referred to as mapping function) object that accepts `Row` and `RowMetadata`.
-The mapping function is called upon row emission with `Row` and `RowMetadata` objects.
-A `Row` is only valid during the mapping function callback and is invalid outside of the mapping function callback.
-Thus, `Row` objects must be entirely consumed by the mapping function.
-
-The <<rowmetadata>> section contains additional details on metadata.
-
-[[row.methods]]
-== Interface Methods
-
-The following methods are available on the `Row` interface:
-
-* `Object get(int)`
-* `Object get(String)`
-* `<T> T get(int, Class<T>)`
-* `<T> T get(String, Class<T>)`
-
-`get(int[, Class])` methods accept column indexes starting at 0, `get(String[, Class])` methods accept column name aliases as they are represented in the result.
-Column names used as input to the `get` methods are case insensitive.
-Column names do not necessarily reflect the column names as they are in the underlying tables but, rather, how columns are represented (for example, aliased) in the result.
-The following example shows how to create and consume a `Row` by using its index:
-
-.Creating and Consuming a `Row` using its index
-====
-[source,java]
-----
-// result is a Result object
-Publisher<Object> values = result.map((row, rowMetadata) -> row.get(0));
-----
-====
-
-The following example shows how to create and consume a `Row` by using its column name:
-
-.Creating and Consuming a `Row` by using its column name
-====
-[source,java]
-----
-// result is a Result object
-Publisher<Object> titles = result.map((row, rowMetadata) -> row.get("title"));
-----
-====
-
-Calling `get` without specifying a target type returns a suitable value representation according to <<datatypes.mapping>>.
-When you specify a target type, the R2DBC driver tries to convert the value to the target type.
-The following example shows how to creat and consume a `Row` with type conversion:
-
-.Creating and Consuming a `Row` with type conversion
-====
-[source,java]
-----
-// result is a Result object
-Publisher<String> values = result.map((row, rowMetadata) -> row.get(0, String.class));
-----
-====
-
-You can also consume multiple columns from a `Row`, as the following example shows:
-
-.Consuming multiple columns from a `Row`
-====
-[source,java]
-----
-// result is a Result object
-Publisher<Book> values = result.map((row, rowMetadata) -> {
-    String title = row.get("title", String.class);
-    String author = row.get("author", String.class);
-
-    return new Book(title, author);
-});
-----
-====
-
-When the column value in the database is SQL `NULL`, it can be returned to the Java application as `null`.
-
-NOTE: `null` values cannot be returned as Reactive Streams values and must be wrapped for subsequent usage.
-
-NOTE: Invalidating a `Row` does *not* release `Blob` and `Clob` objects that were obtained from the `Row`. These objects remain valid for at least the duration of the transaction in which they were created, unless their `discard()` method is called.

--- a/r2dbc-spec/src/main/asciidoc/row-metadata.adoc
+++ b/r2dbc-spec/src/main/asciidoc/row-metadata.adoc
@@ -17,7 +17,7 @@ Consequently, `ColumnMetadata` declares two sets of methods: methods that must b
 == Obtaining a `RowMetadata` Object
 
 A `RowMetadata` object is created during tabular results consumption through `Result.map(…)`.
-It is created for each row. The following example illustrates retrieval and usage by using an anonymous inner class:
+It is created for each row.The following example illustrates retrieval and usage by using an anonymous inner class:
 
 .Using `RowMetadata` and retrieving `ColumnMetadata`
 ====
@@ -29,10 +29,10 @@ result.map(new BiFunction<Row, RowMetadata, Object>() {
     @Override
     public Object apply(Row row, RowMetadata rowMetadata) {
         ColumnMetadata my_column = rowMetadata.getColumnMetadata("my_column");
-        ColumnMetadata.Nullability nullability = my_column.getNullability();
+        Nullability nullability = my_column.getNullability();
         // …
     }
-})
+});
 ----
 ====
 

--- a/r2dbc-spec/src/main/asciidoc/rows.adoc
+++ b/r2dbc-spec/src/main/asciidoc/rows.adoc
@@ -1,0 +1,88 @@
+[[rows]]
+== Rows
+
+A `Row` object represents a single row of tabular results.
+
+[[row.values]]
+=== Retrieving Values
+
+The `Result` interface provides a `map(…)` method for retrieving values from `Row` objects.
+The `map` method accepts a `BiFunction` (also referred to as mapping function) object that accepts `Row` and `RowMetadata`.
+The mapping function is called upon row emission with `Row` and `RowMetadata` objects.
+A `Row` is only valid during the mapping function callback and is invalid outside of the mapping function callback.
+Thus, `Row` objects must be entirely consumed by the mapping function.
+The overloaded `map` method accepting a `Function` object for `Readable` can be called with either `Row` or `OutParameters` objects or vendor-specific extensions.
+
+The <<rowmetadata>> section contains additional details on metadata.
+
+[[row.methods]]
+== Interface Methods
+
+The following methods are available on the `Row` interface:
+
+* `Object get(int)` (inherited from `Readable`)
+* `Object get(String)` (inherited from `Readable`)
+* `<T> T get(int, Class<T>)` (inherited from `Readable`)
+* `<T> T get(String, Class<T>)` (inherited from `Readable`)
+* `RowMetadata getMetadata()`
+
+`get(int[, Class])` methods accept column indexes starting at `0`, `get(String[, Class])` methods accept column name aliases as they are represented in the result.
+Column names used as input to the `get` methods are case-insensitive.
+Column names do not necessarily reflect the column names as they are in the underlying tables but, rather, how columns are represented (for example, aliased) in the result.
+The following example shows how to create and consume a `Row` by using its index:
+
+.Creating and Consuming a `Row` by obtaining a column by index
+====
+[source,java]
+----
+// result is a Result object
+Publisher<Object> values = result.map((row, rowMetadata) -> row.get(0));
+----
+====
+
+The following example shows how to create and consume a `Row` by using its column name:
+
+.Creating and Consuming a `Row` by obtaining a column by name
+====
+[source,java]
+----
+// result is a Result object
+Publisher<Object> titles = result.map((row, rowMetadata) -> row.get("title"));
+----
+====
+
+Calling `get` without specifying a target type returns a suitable value representation according to <<datatypes.mapping>>.
+When specifying a target type, the R2DBC driver tries to convert the value to the target type.
+The following example shows how to create and consume a `Row` with type conversion:
+
+.Creating and Consuming a `Row` with type conversion
+====
+[source,java]
+----
+// result is a Result object
+Publisher<String> values = result.map((row, rowMetadata) -> row.get(0, String.class));
+----
+====
+
+You can also consume multiple columns from a `Row`, as the following example shows:
+
+.Consuming multiple columns from a `Row`
+====
+[source,java]
+----
+// result is a Result object
+Publisher<Book> values = result.map((row, rowMetadata) -> {
+    String title = row.get("title", String.class);
+    String author = row.get("author", String.class);
+
+    return new Book(title, author);
+});
+----
+====
+
+When the column value in the database is SQL `NULL`, it can be returned to the Java application as `null`.
+
+NOTE: `null` values cannot be returned as Reactive Streams values and must be wrapped for subsequent usage.
+
+NOTE: Invalidating a `Row` does *not* release `Blob` and `Clob` objects that were obtained from the `Row`.
+These objects remain valid for at least the duration of the transaction in which they were created, unless their `discard()` method is called.

--- a/r2dbc-spec/src/main/asciidoc/statements.adoc
+++ b/r2dbc-spec/src/main/asciidoc/statements.adoc
@@ -1,7 +1,7 @@
 [[statements]]
 = Statements
 
-This section describes the `Statement` interface. It also describes related topics, including parameterized statement and auto-generated keys.
+This section describes the `Statement` interface.It also describes related topics, including parameterized statement and auto-generated keys.
 
 [[statements.interface]]
 == The Statement Interface
@@ -176,6 +176,51 @@ statement.bind(0, Parameters.in(R2dbcType.VARCHAR));
 
 NOTE: Not all databases allow for a non-typed `NULL` to be sent to the underlying database.
 
+[[statements.in-out]]
+=== Setting `IN/OUT` and `OUT` Parameters
+
+Statements can take three kinds of parameters:
+
+* `IN` parameters (default type) as described in <<statements.bind>>.
+* `IN/OUT` parameters.
+* `OUT` parameters.
+
+The parameter can be specified as either an ordinal parameter or a named parameter.
+A value must be set for each parameter marker in the statement that represents an `IN` or `IN/OUT` parameter.
+`OUT` parameters are generally not associated with a value and may require a type hint.
+
+Parameter types can either make use of type inference by specifying the value or a Java `Class` or reference a `Type`.
+
+`IN/OUT` parameters are assigned values whose result can be retrieved after running the statement as described in <<out-parameters>>.
+Parameters are assigned using the `bind(…)` methods as described in <<statements.bind>>.
+
+The following example shows how to set a `IN/OUT` parameter:
+
+.Setting a `IN/OUT` parameter value using type inference.
+====
+[source,java]
+----
+// connection is a Connection object
+Statement statement = connection.createStatement("CALL my_proc ($1)");
+statement.bind(0, Parameters.inOut("John Doe"));
+----
+====
+
+`OUT` parameters are value-less parameters whose result can be retrieved after running the statement as described in <<out-parameters>>.
+Parameters are assigned using the `bind(…)` methods as described in <<statements.bind>>.
+
+The following example shows how to set a `OUT` parameter:
+
+.Setting a `OUT` parameter value using type inference.
+====
+[source,java]
+----
+// connection is a Connection object
+Statement statement = connection.createStatement("CALL my_proc ($1)");
+statement.bind(0, Parameters.out(String.class));
+----
+====
+
 [[statements.generated-values]]
 == Retrieving Auto Generated Values
 
@@ -196,7 +241,7 @@ Statement statement = connection.createStatement("INSERT INTO books (author, pub
 Publisher<? extends Result> publisher = statement.execute();
 
 // later
-result.map((row, metadata) -> row.get("id"));
+result.map((readable) -> readable.get("id"));
 ----
 ====
 

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockOutParameters.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockOutParameters.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi.test;
+
+import io.r2dbc.spi.OutParameters;
+import io.r2dbc.spi.OutParametersMetadata;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public final class MockOutParameters implements OutParameters {
+
+    private final Map<Identified, Object> identified;
+
+    private final OutParametersMetadata metadata;
+
+    private MockOutParameters(Map<Identified, Object> identified, OutParametersMetadata metadata) {
+        this.identified = Assert.requireNonNull(identified, "identified must not be null");
+        this.metadata = Assert.requireNonNull(metadata, "metadata must not be null");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static MockOutParameters empty() {
+        return builder().build();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(int index, Class<T> type) {
+
+        Assert.requireNonNull(type, "type must not be null");
+
+        Identified identified = new Identified(index, type);
+
+        if (!this.identified.containsKey(identified)) {
+            throw new AssertionError(String.format("Unexpected call to get(Object, Class) with values '%s', '%s'", index, type.getName()));
+        }
+
+        return (T) this.identified.get(identified);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(String name, Class<T> type) {
+
+        Assert.requireNonNull(name, "name must not be null");
+        Assert.requireNonNull(type, "type must not be null");
+
+        Identified identified = new Identified(name, type);
+
+        if (!this.identified.containsKey(identified)) {
+            throw new AssertionError(String.format("Unexpected call to get(Object, Class) with values '%s', '%s'", name, type.getName()));
+        }
+
+        return (T) this.identified.get(identified);
+    }
+
+    @Override
+    public OutParametersMetadata getMetadata() {
+        return this.metadata;
+    }
+
+    @Override
+    public String toString() {
+        return "MockOutParameters{" +
+            "identified=" + this.identified +
+            '}';
+    }
+
+    public static final class Builder {
+
+        private final Map<Identified, Object> identified = new HashMap<>();
+
+        private OutParametersMetadata metadata = MockOutParametersMetadata.empty();
+
+        private Builder() {
+        }
+
+        public MockOutParameters build() {
+            return new MockOutParameters(this.identified, this.metadata);
+        }
+
+        public Builder identified(Object identifier, Class<?> type, @Nullable Object value) {
+            Assert.requireNonNull(identifier, "identifier must not be null");
+            Assert.requireNonNull(type, "type must not be null");
+
+            this.identified.put(new Identified(identifier, type), value);
+            return this;
+        }
+
+        public Builder metadata(OutParametersMetadata outParametersMetadata) {
+            this.metadata = Assert.requireNonNull(outParametersMetadata, "outParametersMetadata must not be null");
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "Builder{" +
+                "identified=" + this.identified +
+                "outParametersMetadata=" + this.metadata +
+                '}';
+        }
+
+    }
+
+    private static final class Identified {
+
+        private final Object identifier;
+
+        private final Class<?> type;
+
+        private Identified(Object identifier, Class<?> type) {
+            this.identifier = Assert.requireNonNull(identifier, "identifier must not be null");
+            this.type = Assert.requireNonNull(type, "type must not be null");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Identified that = (Identified) o;
+            return Objects.equals(this.identifier, that.identifier) &&
+                Objects.equals(this.type, that.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.identifier, this.type);
+        }
+
+        @Override
+        public String toString() {
+            return "Identified{" +
+                "identifier=" + this.identifier +
+                ", type=" + this.type +
+                '}';
+        }
+
+    }
+
+}

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockOutParametersMetadata.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockOutParametersMetadata.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi.test;
+
+import io.r2dbc.spi.OutParameterMetadata;
+import io.r2dbc.spi.OutParametersMetadata;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public final class MockOutParametersMetadata implements OutParametersMetadata {
+
+    private final List<OutParameterMetadata> outParameterMetadatas;
+
+    private MockOutParametersMetadata(List<OutParameterMetadata> outParameterMetadatas) {
+        this.outParameterMetadatas = Assert.requireNonNull(outParameterMetadatas, "outParameterMetadatas must not be null");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static MockOutParametersMetadata empty() {
+        return builder().build();
+    }
+
+    @Override
+    public OutParameterMetadata getParameterMetadata(int index) {
+        return this.outParameterMetadatas.get(index);
+    }
+
+    @Override
+    public OutParameterMetadata getParameterMetadata(String name) {
+        Assert.requireNonNull(name, "name must not be null");
+
+        for (OutParameterMetadata parameterMetadata : this.outParameterMetadatas) {
+            if (parameterMetadata.getName().equalsIgnoreCase(name)) {
+                return parameterMetadata;
+            }
+        }
+
+        throw new NoSuchElementException(String.format("Out Parameter %s not found", name));
+    }
+
+    @Override
+    public List<OutParameterMetadata> getParameterMetadatas() {
+        return this.outParameterMetadatas;
+    }
+
+    @Override
+    public String toString() {
+        return "MockOutParametersMetadata{" +
+            "outParameterMetadatas=" + this.outParameterMetadatas +
+            '}';
+    }
+
+    public static final class Builder {
+
+        private final List<OutParameterMetadata> outParameterMetadatas = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        public MockOutParametersMetadata build() {
+            return new MockOutParametersMetadata(this.outParameterMetadatas);
+        }
+
+        public Builder outParameterMetadata(OutParameterMetadata outParameterMetadata) {
+            Assert.requireNonNull(outParameterMetadata, "outParameterMetadata must not be null");
+
+            this.outParameterMetadatas.add(outParameterMetadata);
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "Builder{" +
+                "outParameterMetadatas=" + this.outParameterMetadatas +
+                '}';
+        }
+
+    }
+
+}

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockResult.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockResult.java
@@ -24,7 +24,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockRow.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockRow.java
@@ -17,6 +17,7 @@
 package io.r2dbc.spi.test;
 
 import io.r2dbc.spi.Row;
+import io.r2dbc.spi.RowMetadata;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,8 +27,11 @@ public final class MockRow implements Row {
 
     private final Map<Identified, Object> identified;
 
-    private MockRow(Map<Identified, Object> identified) {
+    private final RowMetadata rowMetadata;
+
+    private MockRow(Map<Identified, Object> identified, RowMetadata rowMetadata) {
         this.identified = Assert.requireNonNull(identified, "identified must not be null");
+        this.rowMetadata = Assert.requireNonNull(rowMetadata, "rowMetadata must not be null");
     }
 
     public static Builder builder() {
@@ -70,6 +74,11 @@ public final class MockRow implements Row {
     }
 
     @Override
+    public RowMetadata getMetadata() {
+        return this.rowMetadata;
+    }
+
+    @Override
     public String toString() {
         return "MockRow{" +
             "identified=" + this.identified +
@@ -80,11 +89,13 @@ public final class MockRow implements Row {
 
         private final Map<Identified, Object> identified = new HashMap<>();
 
+        private RowMetadata metadata = MockRowMetadata.empty();
+
         private Builder() {
         }
 
         public MockRow build() {
-            return new MockRow(this.identified);
+            return new MockRow(this.identified, this.metadata);
         }
 
         public Builder identified(Object identifier, Class<?> type, @Nullable Object value) {
@@ -95,12 +106,19 @@ public final class MockRow implements Row {
             return this;
         }
 
+        public Builder metadata(RowMetadata rowMetadata) {
+            this.metadata = Assert.requireNonNull(rowMetadata, "rowMetadata must not be null");
+            return this;
+        }
+
         @Override
         public String toString() {
             return "Builder{" +
                 "identified=" + this.identified +
+                "rowMetadata=" + this.metadata +
                 '}';
         }
+
     }
 
     private static final class Identified {

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockRowMetadata.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockRowMetadata.java
@@ -63,7 +63,7 @@ public final class MockRowMetadata implements RowMetadata {
     public ColumnMetadata getColumnMetadata(String name) {
         Assert.requireNonNull(name, "name must not be null");
 
-        for (ColumnMetadata columnMetadata : columnMetadatas) {
+        for (ColumnMetadata columnMetadata : this.columnMetadatas) {
             if (columnMetadata.getName().equalsIgnoreCase(name)) {
                 return columnMetadata;
             }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/OutParameterMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/OutParameterMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,11 @@
 package io.r2dbc.spi;
 
 /**
- * Represents the metadata for a column of the results returned from a query.  The implementation of all methods except {@link #getName()}  is optional for drivers.  Column metadata is optionally
+ * Represents the metadata for an {@code OUT} parameter.  The implementation of all methods except {@link #getName()}  is optional for drivers.  Parameter metadata is optionally
  * available as by-product of statement execution on a best-effort basis.
+ *
+ * @since 0.9
  */
-public interface ColumnMetadata extends ReadableMetadata {
+public interface OutParameterMetadata extends ReadableMetadata {
 
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/OutParameters.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/OutParameters.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+/**
+ * Represents a set of {@code OUT} parameters returned from a stored procedure.
+ * Values from out parameters can be either retrieved by specifying a parameter name or the parameter index.
+ * Parameter indexes are {@code 0}-based.
+ *
+ * <p> Parameter names used as input to getter methods are case insensitive.
+ * When a get method is called with a parameter name and several parameters have the same name, then the value of the first matching parameter will be returned.
+ * Parameters that are not explicitly named in the query should be referenced through parameter indexes.
+ *
+ * <p>For maximum portability, parameters within each {@link OutParameters} should be read in left-to-right order, and each parameter should be read only once.
+ *
+ * <p>{@link #get(String)} and {@link #get(int)} without specifying a target type returns a suitable value representation.  The R2DBC specification contains a mapping table that shows default
+ * mappings between database types and Java types.
+ * Specifying a target type, the R2DBC driver attempts to convert the value to the target type.
+ * <p>A parameter is invalidated after consumption.
+ * <p>The number, type and characteristics of parameters are described through {@link OutParametersMetadata}.
+ *
+ * @since 0.9
+ */
+public interface OutParameters extends Readable {
+
+    /**
+     * Returns the {@link OutParametersMetadata} for all out parameters.
+     *
+     * @return the {@link OutParametersMetadata} for all out parameters
+     */
+    OutParametersMetadata getMetadata();
+
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/OutParametersMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/OutParametersMetadata.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Represents the metadata for {@code OUT} parameters of the results returned from a stored procedure.
+ * Metadata for parameters can be either retrieved by specifying a out parameter name or the out parameter index.
+ * Parameter indexes are {@code 0}-based.
+ */
+public interface OutParametersMetadata {
+
+    /**
+     * Returns the {@link OutParameterMetadata} for one out parameter.
+     *
+     * @param index the out parameter index starting at 0
+     * @return the {@link OutParameterMetadata} for one out parameter
+     * @throws ArrayIndexOutOfBoundsException if the {@code index} is less than zero or greater than the number of available out parameters.
+     */
+    OutParameterMetadata getParameterMetadata(int index);
+
+    /**
+     * Returns the {@link OutParameterMetadata} for one parameter.
+     *
+     * @param name the name of the out parameter.  Parameter names are case insensitive.
+     * @return the {@link OutParameterMetadata} for one out parameter
+     * @throws IllegalArgumentException if {@code name} is {@code null}
+     * @throws NoSuchElementException   if there is no out parameter with the {@code name}
+     */
+    OutParameterMetadata getParameterMetadata(String name);
+
+    /**
+     * Returns the {@link OutParameterMetadata} for all out parameters.
+     *
+     * @return the {@link OutParameterMetadata} for all out parameters
+     */
+    List<? extends OutParameterMetadata> getParameterMetadatas();
+
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Readable.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Readable.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+/**
+ * Represents a readable object, for example a set of columns or {@code OUT} parameters from a database query, later on referred to as items.
+ * Values can for columns or {@code OUT} parameters be either retrieved by specifying a name or the index.
+ * Indexes are {@code 0}-based.
+ *
+ * <p> Column and {@code OUT} parameter names used as input to getter methods are case insensitive.
+ * When a {@code get} method is called with a name and several items have the same name, then the value of the first matching item will be returned.
+ * Items that are not explicitly named in the query should be referenced through indexes.
+ *
+ * <p>For maximum portability, items within each {@link Readable} should be read in left-to-right order, and each item should be read only once.
+ *
+ * <p>{@link #get(String)} and {@link #get(int)} without specifying a target type returns a suitable value representation.  The R2DBC specification contains a mapping table that shows default
+ * mappings between database types and Java types.
+ * Specifying a target type, the R2DBC driver attempts to convert the value to the target type.
+ * <p>A item is invalidated after consumption.
+ *
+ * @see Row
+ * @see OutParameters
+ * @since 0.9
+ */
+public interface Readable {
+
+    /**
+     * Returns the value using the default type mapping.  The default implementation of this method calls {@link #get(int, Class)} passing {@link Object} as the type
+     * to allow the implementation to make the loosest possible match.
+     *
+     * @param index the index of the parameter starting at {@code 0}
+     * @return the value.  Value can be {@code null}.
+     */
+    @Nullable
+    default Object get(int index) {
+        return get(index, Object.class);
+    }
+
+    /**
+     * Returns the value for a parameter.  Use {@link Object} to allow the implementation to make the loosest possible match.
+     *
+     * @param index the index starting at {@code 0}
+     * @param type  the type of item to return.  This type must be assignable to, and allows for variance.
+     * @param <T>   the type of the item being returned.
+     * @return the value.  Value can be {@code null}.
+     * @throws IllegalArgumentException if {@code type} is {@code null}
+     */
+    @Nullable
+    <T> T get(int index, Class<T> type);
+
+    /**
+     * Returns the value for a parameter using the default type mapping.  The default implementation of this method calls {@link #get(String, Class)} passing {@link Object} as the type in
+     * order to allow the implementation to make the loosest possible match.
+     *
+     * @param name the name
+     * @return the value.  Value can be {@code null}.
+     * @throws IllegalArgumentException if {@code name} is {@code null}
+     */
+    @Nullable
+    default Object get(String name) {
+        return get(name, Object.class);
+    }
+
+    /**
+     * Returns the value.  Use {@link Object} to allow the implementation to make the loosest possible match.
+     *
+     * @param name the name
+     * @param type the type of item to return.  This type must be assignable to, and allows for variance.
+     * @param <T>  the type of the item being returned.
+     * @return the value.  Value can be {@code null}.
+     * @throws IllegalArgumentException if {@code name} or {@code type} is {@code null}
+     */
+    @Nullable
+    <T> T get(String name, Class<T> type);
+
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ReadableMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ReadableMetadata.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+/**
+ * Represents the metadata for readable object, for example a column of the results returned from a query or {@code OUT} parameter as result of running a stored procedure.
+ * The implementation of all methods except {@link #getName()}  is optional for drivers.  Metadata is optionally available as by-product of statement execution on a best-effort basis.
+ *
+ * @see ColumnMetadata
+ * @see OutParameterMetadata
+ * @since 0.9
+ */
+public interface ReadableMetadata {
+
+    /**
+     * Returns the primary Java {@link Class type}.  This type can be considered the native representation that is used to exchange values with the least loss in precision.
+     * <p>
+     * <strong>Implementation notes</strong>
+     * Drivers should implement this method.  The method should return the actual type and refrain from returning {@code Object.class}.  The default implementation returns {@code null}.
+     * Drivers may need to inspect the value and perform parts of decoding to determine the native Java type.  This method
+     * should be expected to run in non-constant time.
+     *
+     * @return the primary Java {@link Class type} or {@code null} if the type is not available.
+     * @see Row#get
+     * @see OutParameters#get
+     */
+    @Nullable
+    default Class<?> getJavaType() {
+        return null;
+    }
+
+    /**
+     * Returns the database {@link Type}.
+     *
+     * @return the database {@link Type} descriptor.
+     * @since 0.9
+     */
+    Type getType();
+
+    /**
+     * Returns the name.
+     * <p>
+     * The name does not necessarily reflect the names how they are in the underlying tables but rather how results are represented (e.g. aliased) in the result.
+     *
+     * @return the name of the item
+     */
+    String getName();
+
+    /**
+     * Returns the native type descriptor that potentially exposes more metadata.
+     * <p>
+     * <strong>Implementation notes</strong>
+     * Drivers should implement this method if they can expose a driver-specific type metadata object exposing additional information.  The default implementation returns {@code null}.
+     *
+     * @return the native type descriptor that potentially exposes more metadata or {@code null} if no native type descriptor is available.
+     */
+    @Nullable
+    default Object getNativeTypeMetadata() {
+        return null;
+    }
+
+    /**
+     * Returns the nullability of values.
+     * <p>
+     * <strong>Implementation notes</strong>
+     * Implementation of this method is optional.  The default implementation returns {@link Nullability#UNKNOWN}.
+     *
+     * @return the nullability of values.
+     * @see Nullability
+     */
+    default Nullability getNullability() {
+        return Nullability.UNKNOWN;
+    }
+
+    /**
+     * Returns the precision.
+     * <p>
+     * For numeric data, this is the maximum precision.
+     * For character data, this is the length in characters.
+     * For datetime data types, this is the length in bytes required to represent the value (assuming the
+     * maximum allowed precision of the fractional seconds component).
+     * For binary data, this is the length in bytes.
+     * Returns {@code null} for data types where data type size is not applicable or if the precision cannot be provided.
+     * <p>
+     * <strong>Implementation notes</strong>
+     * Implementation of this method is optional.  The default implementation returns {@code null}.
+     *
+     * @return the precision or {@code null} if the precision is not available.
+     */
+    @Nullable
+    default Integer getPrecision() {
+        return null;
+    }
+
+    /**
+     * Returns the scale.
+     * <p>
+     * This is the number of digits to right of the decimal point.
+     * Returns {@code null} for data types where the scale is not applicable or if the precision cannot be provided.
+     * <p>
+     * <strong>Implementation notes</strong>
+     * Implementation of this method is optional.  The default implementation returns {@code null}.
+     *
+     * @return the scale or {@code null} if the scale is not available.
+     */
+    @Nullable
+    default Integer getScale() {
+        return null;
+    }
+
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Result.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Result.java
@@ -22,7 +22,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
- * Represents the results of a query against a database.  Results can be consumed only once by either consuming {@link #getRowsUpdated()}, or {@link #map(BiFunction)}.
+ * Represents the results of a query against a database.  Results can be consumed only once by either consuming {@link #getRowsUpdated()}, {@link #map(BiFunction)}, or {@link #map(Function)}.
  *
  * <p>A {@link Result} object maintains a consumption state that may be backed by a cursor pointing
  * to its current row of data or out parameters.  A {@link Result} allows read-only and forward-only consumption of statement results.
@@ -50,5 +50,23 @@ public interface Result {
      * @throws IllegalStateException    if the result was consumed
      */
     <T> Publisher<T> map(BiFunction<Row, RowMetadata, ? extends T> mappingFunction);
+
+    /**
+     * Returns a mapping of the rows/out parameters that are the results of a query against a database.  May be empty if the query did not return any results.  A {@link Readable} can be only
+     * considered valid within a {@link Function mapping function} callback.
+     *
+     * @param mappingFunction the {@link Function} that maps a {@link Readable} to a value
+     * @param <T>             the type of the mapped value
+     * @return a mapping of the rows that are the results of a query against a database
+     * @throws IllegalArgumentException if {@code mappingFunction} is {@code null}
+     * @throws IllegalStateException    if the result was consumed
+     * @see Row
+     * @see OutParameters
+     * @since 0.9
+     */
+    default <T> Publisher<T> map(Function<? super Readable, ? extends T> mappingFunction) {
+        Assert.requireNonNull(mappingFunction, "mappingFunction must not be null");
+        return map((row, metadata) -> mappingFunction.apply(row));
+    }
 
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Result.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Result.java
@@ -19,13 +19,15 @@ package io.r2dbc.spi;
 import org.reactivestreams.Publisher;
 
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
- * Represents the results of a query against a database.  Results can be consumed only once by either consuming {@link #getRowsUpdated()} or {@link #map(BiFunction)}.
+ * Represents the results of a query against a database.  Results can be consumed only once by either consuming {@link #getRowsUpdated()}, or {@link #map(BiFunction)}.
  *
  * <p>A {@link Result} object maintains a consumption state that may be backed by a cursor pointing
- * to its current row of data.  A {@link Result} allows read-only and forward-only consumption of statement results.
- * Thus, you can consume either {@link #getRowsUpdated()} or {@link #map(BiFunction) Rows} through it only once and only from the first row to the last row.
+ * to its current row of data or out parameters.  A {@link Result} allows read-only and forward-only consumption of statement results.
+ * Thus, you can consume either {@link #getRowsUpdated()}, {@link #map(BiFunction) Rows}, or {@link #map(Function) Rows or out parameters} through it only once and only from the first to the last
+ * row/parameter set.
  */
 public interface Result {
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Row.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Row.java
@@ -21,7 +21,8 @@ import java.util.function.BiFunction;
 /**
  * Represents a row returned from a database query.
  * Values from columns can be either retrieved by specifying a column name or the column index.
- * Columns are numbered from 0.  Column names do not necessarily reflect the column names how they are in the underlying tables but rather how columns are represented (e.g. aliased) in the result.
+ * Column indexes are {@code 0}-based.  Column names do not necessarily reflect the column names how they are in the underlying tables but rather how columns are represented (e.g. aliased) in the
+ * result.
  *
  * <p> Column names used as input to getter methods are case insensitive.
  * When a get method is called with a column name and several columns have the same name, then the value of the first matching column will be returned.
@@ -31,61 +32,11 @@ import java.util.function.BiFunction;
  * <p>For maximum portability, result columns within each {@link Row} should be read in left-to-right order, and each column should be read only once.
  *
  * <p>{@link #get(String)} and {@link #get(int)} without specifying a target type returns a suitable value representation.  The R2DBC specification contains a mapping table that shows default
- * mappings between database
- * types and Java types.
+ * mappings between database types and Java types.
  * Specifying a target type, the R2DBC driver attempts to convert the value to the target type.
  * <p>A row is invalidated after consumption in the {@link Result#map(BiFunction) mapping function}.
  * <p>The number, type and characteristics of columns are described through {@link RowMetadata}
  */
-public interface Row {
-
-    /**
-     * Returns the value for a column in this row using the default type mapping.  The default implementation of this method calls {@link #get(int, Class)} passing {@link Object} as the type
-     * to allow the implementation to make the loosest possible match.
-     *
-     * @param index the index of the column starting at {@code 0}
-     * @return the value for a column in this row.  Value can be {@code null}.
-     */
-    @Nullable
-    default Object get(int index) {
-        return get(index, Object.class);
-    }
-
-    /**
-     * Returns the value for a column in this row.  Use {@link Object} to allow the implementation to make the loosest possible match.
-     *
-     * @param index the index of the column starting at {@code 0}
-     * @param type  the type of item to return.  This type must be assignable to, and allows for variance.
-     * @param <T>   the type of the item being returned.
-     * @return the value for a column in this row.  Value can be {@code null}.
-     * @throws IllegalArgumentException if {@code type} is {@code null}
-     */
-    @Nullable
-    <T> T get(int index, Class<T> type);
-
-    /**
-     * Returns the value for a column in this row using the default type mapping.  The default implementation of this method calls {@link #get(String, Class)} passing {@link Object} as the type in
-     * order to allow the implementation to make the loosest possible match.
-     *
-     * @param name the name of the column
-     * @return the value for a column in this row.  Value can be {@code null}.
-     * @throws IllegalArgumentException if {@code name} is {@code null}
-     */
-    @Nullable
-    default Object get(String name) {
-        return get(name, Object.class);
-    }
-
-    /**
-     * Returns the value for a column in this row.  Use {@link Object} to allow the implementation to make the loosest possible match.
-     *
-     * @param name the name of the column
-     * @param type the type of item to return.  This type must be assignable to, and allows for variance.
-     * @param <T>  the type of the item being returned.
-     * @return the value for a column in this row.  Value can be {@code null}.
-     * @throws IllegalArgumentException if {@code name} or {@code type} is {@code null}
-     */
-    @Nullable
-    <T> T get(String name, Class<T> type);
+public interface Row extends Readable {
 
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Row.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Row.java
@@ -39,4 +39,12 @@ import java.util.function.BiFunction;
  */
 public interface Row extends Readable {
 
+    /**
+     * Returns the {@link RowMetadata} for all columns in this row.
+     *
+     * @return the {@link RowMetadata} for all columns in this row
+     * @since 0.9
+     */
+    RowMetadata getMetadata();
+
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java
@@ -22,7 +22,8 @@ import java.util.NoSuchElementException;
 /**
  * Represents the metadata for a row of the results returned from a query.
  * Metadata for columns can be either retrieved by specifying a column name or the column index.
- * Columns are numbered from 0.  Column names do not necessarily reflect the column names how they are in the underlying tables but rather how columns are represented (e.g. aliased) in the result.
+ * Columns indexes are {@code 0}-based.  Column names do not necessarily reflect the column names how they are in the underlying tables but rather how columns are represented (e.g. aliased) in the
+ * result.
  */
 public interface RowMetadata {
 


### PR DESCRIPTION
#### Issue description

Add a top-level interface to consume `OUT` parameters. During the course of #215 and #207 we found that the specification requires further interfaces to consume response segments backed by stored procedure outcomes, specifically out parameters.

Out parameters represent a similar approach to gettable data as `Row` and follow the same design principle. Generally, it makes sense to introduce a `Gettable` and metadata abstraction to apply common result consumption patterns regardless of the actual type since it's `get(…)` after all.
 
#### New Public APIs

* `OutParameters`, `OutParametersMetadata`, and `OutParameterMetadata`
* `Gettable` as common super-interface for `OutParameters` and `Row`
* `Row.getMetadata()`
* `Result.map(Function<Gettable, Publisher<T>>)` to consume rows and out parameters
* `ThingMetadata` (lacking a better name) to serve as super-interface for `ColumnMetadata` and `OutParameterMetadata` 

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
