### PR TITLE
Correct Java Type for CLOB and NCLOB

### DIFF
--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcType.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcType.java
@@ -58,12 +58,12 @@ public enum R2dbcType implements Type {
     /**
      * Identifies the generic SQL type {@code CLOB}.
      */
-    CLOB(ByteBuffer.class),
+    CLOB(String.class),
 
     /**
      * Identifies the generic SQL type {@code NCLOB}.
      */
-    NCLOB(ByteBuffer.class),
+    NCLOB(String.class),
 
     // ----------------------------------------------------
     // Boolean types


### PR DESCRIPTION
Declaring String as the Java type mapping for R2dbcType values CLOB and
NCLOB.

Signed-off-by: Michael-A-McMahon <Michael.A.McMahon@oracle.com>

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [ ] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/main/CONTRIBUTING.adoc).
- [ ] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [ ] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/main/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
[resolves #214]
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
