### PR TITLE
Introduction of limiting the time for lock acquisition and limiting execution time for statements

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/changes.adoc
+++ b/r2dbc-spec/src/main/asciidoc/changes.adoc
@@ -35,6 +35,11 @@ Refinement of `RowMetadata`::
 
   * Deprecate `RowMetadata.getColumnNames()` and introduce `RowMetadata.contains(String)` to simplify constraints and usage around column presence checks.
 
+Lock Wait and Statement Timeouts::
+
+  * Introduction of <<connections.lock-acquisition-timeout>> and <<connections.statment-timeout>>.
+  * Introduction of the `Connection.setLockWaitTimeout(Duration)` and `Connection.setStatementTimeout(Duration)` methods.
+
 [[changes.0.8.x]]
 == 0.8
 

--- a/r2dbc-spec/src/main/asciidoc/connections.adoc
+++ b/r2dbc-spec/src/main/asciidoc/connections.adoc
@@ -181,6 +181,16 @@ Options are identified by a literal.
 |`connectTimeout`
 |`java.time.Duration`
 |Connection timeout to obtain a connection.
+
+|`LOCK_WAIT_TIMEOUT`
+|`lockWaitTimeout`
+|`java.time.Duration`
+|Lock acquisition timeout.
+
+|`STATEMENT_TIMEOUT`
+|`statementTimeout`
+|`java.time.Duration`
+|Statement timeout.
 |===
 
 The following rules apply:
@@ -278,3 +288,26 @@ Publisher<Void> close = connection.close();
 ====
 
 See the R2DBC SPI Specification for more details.
+
+[[connections.lock-acquisition-timeout]]
+== Limiting the time for lock acquisition
+
+The lock acquisition timeout can be configured on the `Connection` level allowing to associate the connection with a lock acquisition limit.
+The default lock acquisition timeout is vendor-specific and can be specified for new connections through <<connections.factory.options, connection factory options>>.
+
+If the timeout is exceeded, a `R2dbcTimeoutException` is raised to the client.
+Support for transaction-bound timeouts through <<transactions.transaction-definition.usage,`TransactionDefinition`>> is subject to vendor-specific availability.
+
+[[connections.statment-timeout]]
+== Limiting execution time for statements
+
+The statement timeout can be configured on the `Connection` level allowing to associate the connection with a timeout limit.
+By default there is no limit on the amount of time allowed for a running statement to complete unless specified through <<connections.factory.options, connection factory options>>.
+The minimum amount of time can be used to either let the data source cancel the statement or attempt a client-side cancellation.
+
+Once the data source has had an opportunity to process the request to terminate the running command, a `R2dbcTimeoutException` is raised to the client and no additional processing can occur against the previously running command without re-executing a statement.
+
+The timeout applies to statements through a combination of `Statement#execute`, `Batch#execute` and `Result` consumption.
+In the case of `Batch`/`Statement` batching, it is vendor-specific whether the timeout is applied to individual SQL commands or the entire batch.
+
+Support for transaction-bound timeouts through <<transactions.transaction-definition.usage,`TransactionDefinition`>> is subject to vendor-specific availability.

--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockConnection.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/MockConnection.java
@@ -24,6 +24,8 @@ import io.r2dbc.spi.ValidationDepth;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
+
 public final class MockConnection implements Connection {
 
     private final MockBatch batch;
@@ -49,6 +51,10 @@ public final class MockConnection implements Connection {
     private String rollbackTransactionToSavepointName;
 
     private TransactionDefinition beginTransactionDefinition;
+
+    private Duration lockWaitTimeout;
+
+    private Duration statementTimeout = Duration.ZERO;
 
     private IsolationLevel setTransactionIsolationLevelIsolationLevel;
 
@@ -213,6 +219,27 @@ public final class MockConnection implements Connection {
         return Mono.empty();
     }
 
+    @Nullable
+    public Duration getLockWaitTimeout() {
+        return this.lockWaitTimeout;
+    }
+
+    @Override
+    public Publisher<Void> setLockWaitTimeout(Duration timeout) {
+        this.lockWaitTimeout = timeout;
+        return Mono.empty();
+    }
+
+    public Duration getStatementTimeout() {
+        return this.statementTimeout;
+    }
+
+    @Override
+    public Publisher<Void> setStatementTimeout(Duration timeout) {
+        this.statementTimeout = timeout;
+        return Mono.empty();
+    }
+
     @Override
     public Mono<Void> setTransactionIsolationLevel(IsolationLevel isolationLevel) {
         this.setTransactionIsolationLevelIsolationLevel = Assert.requireNonNull(isolationLevel, "isolation level must not be null");
@@ -239,6 +266,8 @@ public final class MockConnection implements Connection {
             ", releaseSavepointName='" + this.releaseSavepointName + '\'' +
             ", rollbackTransactionCalled=" + this.rollbackTransactionCalled +
             ", rollbackTransactionToSavepointName='" + this.rollbackTransactionToSavepointName + '\'' +
+            ", setLockWaitTimeout=" + this.lockWaitTimeout +
+            ", setStatementTimeout=" + this.statementTimeout +
             ", setTransactionIsolationLevelIsolationLevel=" + this.setTransactionIsolationLevelIsolationLevel +
             ", valid=" + this.valid +
             ", validateCalled=" + this.validateCalled +

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
@@ -73,6 +73,13 @@ public final class ConnectionFactoryOptions {
     public static final Option<String> HOST = Option.valueOf("host");
 
     /**
+     * Lock timeout.
+     *
+     * @since 0.9
+     */
+    public static final Option<Duration> LOCK_WAIT_TIMEOUT = Option.valueOf("lockWaitTimeout");
+
+    /**
      * Password for authentication.
      */
     public static final Option<CharSequence> PASSWORD = Option.sensitiveValueOf("password");
@@ -91,6 +98,13 @@ public final class ConnectionFactoryOptions {
      * Whether to require SSL.
      */
     public static final Option<Boolean> SSL = Option.valueOf("ssl");
+
+    /**
+     * Statement timeout.
+     *
+     * @since 0.9
+     */
+    public static final Option<Duration> STATEMENT_TIMEOUT = Option.valueOf("statementTimeout");
 
     /**
      * User for authentication.


### PR DESCRIPTION
New `setLockWaitTimeout` and `setStatementTimeout` methods on `Connection` along with `ConnectionFactoryOptions`
