### PR TITLE
Add draft for Lifecycle extension

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/changes.adoc
+++ b/r2dbc-spec/src/main/asciidoc/changes.adoc
@@ -8,32 +8,36 @@ The following section reflects the history of changes.
 
 Extended transaction definitions::
 
-  * Introduction of the <<transactions.transaction-definition,`TransactionDefinition`>> interface.
-  * Introduction of the `Connection.beginTransaction(TransactionDefinition)` method.
+* Introduction of the <<transactions.transaction-definition,`TransactionDefinition`>> interface.
+* Introduction of the `Connection.beginTransaction(TransactionDefinition)` method.
 
 Improved Bind Parameter declararation::
 
-  * Support to set <<statements.in-out, IN, IN/OUT, and OUT parameters>>.
-  * Introduction of the `Parameter` interface type hierarchy and the `Parameters` class providing factory methods.
+* Support to set <<statements.in-out, IN, IN/OUT, and OUT parameters>>.
+* Introduction of the `Parameter` interface type hierarchy and the `Parameters` class providing factory methods.
 
 Consumption of OUT Parameters::
 
-  * Introduction of <<out-parameters>>.
-  * Introduction of the `OutParameters`, `OutParametersMetadata`, and `OutParameterMetadata` interfaces.
-  * Introduction of the `Readable` and `ReadableMetadata` interfaces and retrofitting of `Row` and `ColumnMetadata` interfaces.
-  * Introduction of the `Result.map(Function<Readable, T>)` method.
+* Introduction of <<out-parameters>>.
+* Introduction of the `OutParameters`, `OutParametersMetadata`, and `OutParameterMetadata` interfaces.
+* Introduction of the `Readable` and `ReadableMetadata` interfaces and retrofitting of `Row` and `ColumnMetadata` interfaces.
+* Introduction of the `Result.map(Function<Readable, T>)` method.
 
 Consumption of Result Segments::
 
-  * Introduction of the `Result.Segment` interface type hierarchy and `Result.filter(Predicate<Segment>)` and `Result.flatMap(Function<Segment, Publisher<T>>)` methods.
+* Introduction of the `Result.Segment` interface type hierarchy and `Result.filter(Predicate<Segment>)` and `Result.flatMap(Function<Segment, Publisher<T>>)` methods.
+
+Lifecycle extension::
+
+* Introduction of the <<lifecycle, `Lifecycle`>> interface.
 
 Refinement of `Option`::
 
-  * Removal of generic type of `Option.get(ConnectionFactoryOption)`.
+* Removal of generic type of `Option.get(ConnectionFactoryOption)`.
 
 Refinement of `RowMetadata`::
 
-  * Deprecate `RowMetadata.getColumnNames()` and introduce `RowMetadata.contains(String)` to simplify constraints and usage around column presence checks.
+* Deprecate `RowMetadata.getColumnNames()` and introduce `RowMetadata.contains(String)` to simplify constraints and usage around column presence checks.
 
 [[changes.0.8.x]]
 == 0.8

--- a/r2dbc-spec/src/main/asciidoc/extensions.adoc
+++ b/r2dbc-spec/src/main/asciidoc/extensions.adoc
@@ -7,3 +7,5 @@ Extensions provide features that are not mandatory for R2DBC implementations.
 include::wrapped.adoc[leveloffset=+1]
 
 include::closeable.adoc[leveloffset=+1]
+
+include::lifecycle.adoc[leveloffset=+1]

--- a/r2dbc-spec/src/main/asciidoc/lifecycle.adoc
+++ b/r2dbc-spec/src/main/asciidoc/lifecycle.adoc
@@ -1,0 +1,44 @@
+[[lifecycle]]
+= Lifecycle Interface
+
+The `Lifecycle` interface provides methods to notify a connection resource about its lifecycle state.
+Typically used by resource management components such as connection pools to indicate allocation and release phases so that connections may allocate or release resources as needed.
+
+[[lifecycle.usage]]
+== Usage
+
+The `Lifecycle` interface is typically implemented by `Connection` objects.
+Those are notified by their resource manager such as a pool right before returning a cached connection for usage and after usage, right before returning the connection to the pool or closing the connection.
+Connections implementing `Lifecycle` may allocate resources upon `postAllocate` and release these before going into idle state on `preRelease`.
+Lifecycle methods can be used to clean up unfinished transactions or reset the connection state.
+Over the lifespan of a cached resource, lifecycle methods are called multiple times in the sequence of:
+
+1. `ConnectionFactory.create()`
+2. `postAllocate`
+3. Application-specific work
+4. `preRelease`
+5. Repeat from 2. or `Connection.close()`
+
+Error signals emitted by lifecycle method publishers should be propagated appropriately to the caller.
+
+[[lifecycle.methods]]
+== Interface Methods
+
+The following methods are available on the `Lifecycle` interface:
+
+* `postAllocate`
+* `preRelease`
+
+[[lifecycle.postAllocate]]
+== The `postAllocate` Method
+
+The `postAllocate` method is used to return a `Publisher` to signal allocation to a resource.
+Any application-specific work happens after completion of the `Publisher` returned by this method.
+Successive calls to `postAllocate` are expected to no-op.
+
+[[lifecycle.preRelease]]
+== The `preRelease` Method
+
+The `preRelease` method is used to return a `Publisher` to signal release of a resource to idle state.
+Any application-specific work has completed before subscribing to the `Publisher` returned by this method.
+Successive calls to `preRelease` are expected to no-op.

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Lifecycle.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Lifecycle.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.spi;
+
+import org.reactivestreams.Publisher;
+
+/**
+ * A common interface defining methods for allocation/release lifecycle control. The typical use case for this is to notify resources.
+ *
+ * <p>Can be implemented by connections.  Components allocating/releasing connections notify resources implementing this interface about the ongoing activity so that resources can react in a proper
+ * way (e.g. allocating or releasing associated resources).
+ *
+ * @see Connection
+ * @since 0.9
+ */
+public interface Lifecycle {
+
+	/**
+	 * Notifies the resource about its allocation.
+	 * The method is called after creating a new resource or allocating a cached resource before applying any requests.  The resource is ready for usage after completion of the returned
+	 * {@link Publisher}.
+	 *
+	 * @return a {@link Publisher} that indicates that the resource is ready for usage
+	 */
+	Publisher<Void> postAllocate();
+
+	/**
+	 * Notifies the resource that it is about to be released.
+	 * The method is called after finishing its usage and prior to its release/close.  The resource is ready for being released after completion of the returned {@link Publisher}.
+	 *
+	 * @return a {@link Publisher} that indicates that the resource is ready to be released
+	 */
+	Publisher<Void> preRelease();
+
+}


### PR DESCRIPTION
Lifecycle allows Connections to be notified before and after their usage.

