### PR TITLE
Add sql to R2DBC exception hierarchy.

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/exceptions.adoc
+++ b/r2dbc-spec/src/main/asciidoc/exceptions.adoc
@@ -57,6 +57,8 @@ The value of the `SQLState` string depends on the underlying data source.
 The code is an integer value that identifies the error that caused the `R2dbcException` to be thrown.
 Its value and meaning are implementation-specific and may be the actual error code returned by the underlying data source.
 You can retrieve the error code by using the `R2dbcException.getErrorCode()` method.
+* The offending SQL.
+If a particular SQL statement results in an exception then you can can retrieve the SQL text using the `R2dbcException.getSql()` method.
 * A cause.
 This is another `Throwable` that caused this `R2dbcException` to occur.
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcBadGrammarException.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcBadGrammarException.java
@@ -21,14 +21,11 @@ package io.r2dbc.spi;
  */
 public class R2dbcBadGrammarException extends R2dbcNonTransientException {
 
-    private final String offendingSql;
-
     /**
      * Creates a new {@link R2dbcBadGrammarException}.
      */
     public R2dbcBadGrammarException() {
         super();
-        this.offendingSql = null;
     }
 
     /**
@@ -38,7 +35,6 @@ public class R2dbcBadGrammarException extends R2dbcNonTransientException {
      */
     public R2dbcBadGrammarException(@Nullable String reason) {
         super(reason);
-        this.offendingSql = null;
     }
 
     /**
@@ -50,7 +46,6 @@ public class R2dbcBadGrammarException extends R2dbcNonTransientException {
      */
     public R2dbcBadGrammarException(@Nullable String reason, @Nullable String sqlState) {
         super(reason, sqlState);
-        this.offendingSql = null;
     }
 
     /**
@@ -63,7 +58,6 @@ public class R2dbcBadGrammarException extends R2dbcNonTransientException {
      */
     public R2dbcBadGrammarException(@Nullable String reason, @Nullable String sqlState, int errorCode) {
         super(reason, sqlState, errorCode);
-        this.offendingSql = null;
     }
 
     /**
@@ -73,12 +67,25 @@ public class R2dbcBadGrammarException extends R2dbcNonTransientException {
      * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
      *                  conventions
      * @param errorCode a vendor-specific error code representing this failure
-     * @param offendingSql the SQL statement that caused this error
+     * @param sql       the SQL statement that caused this error
+     */
+    public R2dbcBadGrammarException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql) {
+        super(reason, sqlState, errorCode, sql);
+    }
+
+    /**
+     * Creates a new {@link R2dbcBadGrammarException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @param cause     the cause
      */
     public R2dbcBadGrammarException(@Nullable String reason, @Nullable String sqlState, int errorCode,
-                                    @Nullable String offendingSql) {
-        super(reason, sqlState, errorCode);
-        this.offendingSql = offendingSql;
+                                    @Nullable String sql, @Nullable Throwable cause) {
+        super(reason, sqlState, errorCode, sql, cause);
     }
 
     /**
@@ -90,26 +97,8 @@ public class R2dbcBadGrammarException extends R2dbcNonTransientException {
      * @param errorCode a vendor-specific error code representing this failure
      * @param cause     the cause
      */
-    public R2dbcBadGrammarException(@Nullable String reason, @Nullable String sqlState, int errorCode,
-                                    @Nullable Throwable cause) {
+    public R2dbcBadGrammarException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable Throwable cause) {
         super(reason, sqlState, errorCode, cause);
-        this.offendingSql = null;
-    }
-
-    /**
-     * Creates a new {@link R2dbcBadGrammarException}.
-     *
-     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
-     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
-     *                  conventions
-     * @param errorCode a vendor-specific error code representing this failure
-     * @param offendingSql the SQL statement that caused this error
-     * @param cause     the cause
-     */
-    public R2dbcBadGrammarException(@Nullable String reason, @Nullable String sqlState, int errorCode,
-                                    @Nullable String offendingSql, @Nullable Throwable cause) {
-        super(reason, sqlState, errorCode, cause);
-        this.offendingSql = offendingSql;
     }
 
     /**
@@ -122,7 +111,6 @@ public class R2dbcBadGrammarException extends R2dbcNonTransientException {
      */
     public R2dbcBadGrammarException(@Nullable String reason, @Nullable String sqlState, @Nullable Throwable cause) {
         super(reason, sqlState, cause);
-        this.offendingSql = null;
     }
 
     /**
@@ -133,7 +121,6 @@ public class R2dbcBadGrammarException extends R2dbcNonTransientException {
      */
     public R2dbcBadGrammarException(@Nullable String reason, @Nullable Throwable cause) {
         super(reason, cause);
-        this.offendingSql = null;
     }
 
     /**
@@ -143,16 +130,17 @@ public class R2dbcBadGrammarException extends R2dbcNonTransientException {
      */
     public R2dbcBadGrammarException(@Nullable Throwable cause) {
         super(cause);
-        this.offendingSql = null;
     }
 
     /**
-     * Returns the offending SQL String.
+     * Returns the SQL that led to the problem (if known).
      *
-     * @return offendingSql
+     * @return the SQL
+     * @see #getSql()
      */
     @Nullable
     public String getOffendingSql() {
-        return this.offendingSql;
+        return super.getSql();
     }
+
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcDataIntegrityViolationException.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcDataIntegrityViolationException.java
@@ -67,10 +67,38 @@ public class R2dbcDataIntegrityViolationException extends R2dbcNonTransientExcep
      * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
      *                  conventions
      * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @since 0.9
+     */
+    public R2dbcDataIntegrityViolationException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql) {
+        super(reason, sqlState, errorCode, sql);
+    }
+
+    /**
+     * Creates a new {@link R2dbcDataIntegrityViolationException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @param cause     the cause
+     * @since 0.9
+     */
+    public R2dbcDataIntegrityViolationException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql, @Nullable Throwable cause) {
+        super(reason, sqlState, errorCode, sql, cause);
+    }
+
+    /**
+     * Creates a new {@link R2dbcDataIntegrityViolationException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
      * @param cause     the cause
      */
-    public R2dbcDataIntegrityViolationException(@Nullable String reason, @Nullable String sqlState, int errorCode,
-                                                @Nullable Throwable cause) {
+    public R2dbcDataIntegrityViolationException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable Throwable cause) {
         super(reason, sqlState, errorCode, cause);
     }
 
@@ -82,8 +110,7 @@ public class R2dbcDataIntegrityViolationException extends R2dbcNonTransientExcep
      *                 conventions
      * @param cause    the cause
      */
-    public R2dbcDataIntegrityViolationException(@Nullable String reason, @Nullable String sqlState,
-                                                @Nullable Throwable cause) {
+    public R2dbcDataIntegrityViolationException(@Nullable String reason, @Nullable String sqlState, @Nullable Throwable cause) {
         super(reason, sqlState, cause);
     }
 
@@ -105,4 +132,5 @@ public class R2dbcDataIntegrityViolationException extends R2dbcNonTransientExcep
     public R2dbcDataIntegrityViolationException(@Nullable Throwable cause) {
         super(cause);
     }
+
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcException.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcException.java
@@ -23,7 +23,11 @@ public abstract class R2dbcException extends RuntimeException {
 
     private final int errorCode;
 
+    @Nullable
     private final String sqlState;
+
+    @Nullable
+    private final String sql;
 
     /**
      * Creates a new {@link R2dbcException}.
@@ -61,7 +65,39 @@ public abstract class R2dbcException extends RuntimeException {
      * @param errorCode a vendor-specific error code representing this failure
      */
     public R2dbcException(@Nullable String reason, @Nullable String sqlState, int errorCode) {
-        this(reason, sqlState, errorCode, null);
+        this(reason, sqlState, errorCode, null, null);
+    }
+
+    /**
+     * Creates a new {@link R2dbcException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @since 0.9
+     */
+    public R2dbcException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql) {
+        this(reason, sqlState, errorCode, sql, null);
+    }
+
+    /**
+     * Creates a new {@link R2dbcException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @param cause     the cause
+     * @since 0.9
+     */
+    public R2dbcException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql, @Nullable Throwable cause) {
+        super(reason, cause);
+        this.sqlState = sqlState;
+        this.errorCode = errorCode;
+        this.sql = sql;
     }
 
     /**
@@ -74,9 +110,7 @@ public abstract class R2dbcException extends RuntimeException {
      * @param cause     the cause
      */
     public R2dbcException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable Throwable cause) {
-        super(reason, cause);
-        this.sqlState = sqlState;
-        this.errorCode = errorCode;
+        this(reason, sqlState, errorCode, null, cause);
     }
 
     /**
@@ -116,7 +150,7 @@ public abstract class R2dbcException extends RuntimeException {
      * @return the vendor-specific error code
      */
     public final int getErrorCode() {
-        return errorCode;
+        return this.errorCode;
     }
 
     /**
@@ -127,6 +161,17 @@ public abstract class R2dbcException extends RuntimeException {
     @Nullable
     public final String getSqlState() {
         return this.sqlState;
+    }
+
+    /**
+     * Returns the SQL that led to the problem (if known).
+     *
+     * @return the SQL
+     * @since 0.9
+     */
+    @Nullable
+    public final String getSql() {
+        return this.sql;
     }
 
     @Override

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcNonTransientException.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcNonTransientException.java
@@ -72,10 +72,38 @@ public abstract class R2dbcNonTransientException extends R2dbcException {
      * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
      *                  conventions
      * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @since 0.9
+     */
+    public R2dbcNonTransientException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql) {
+        super(reason, sqlState, errorCode, sql);
+    }
+
+    /**
+     * Creates a new {@link R2dbcNonTransientException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @param cause     the cause
+     * @since 0.9
+     */
+    public R2dbcNonTransientException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql, @Nullable Throwable cause) {
+        super(reason, sqlState, errorCode, sql, cause);
+    }
+
+    /**
+     * Creates a new {@link R2dbcNonTransientException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
      * @param cause     the cause
      */
-    public R2dbcNonTransientException(@Nullable String reason, @Nullable String sqlState, int errorCode,
-                                      @Nullable Throwable cause) {
+    public R2dbcNonTransientException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable Throwable cause) {
         super(reason, sqlState, errorCode, cause);
     }
 
@@ -109,4 +137,5 @@ public abstract class R2dbcNonTransientException extends R2dbcException {
     public R2dbcNonTransientException(@Nullable Throwable cause) {
         super(cause);
     }
+
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcNonTransientResourceException.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcNonTransientResourceException.java
@@ -67,10 +67,38 @@ public class R2dbcNonTransientResourceException extends R2dbcNonTransientExcepti
      * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
      *                  conventions
      * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @since 0.9
+     */
+    public R2dbcNonTransientResourceException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql) {
+        super(reason, sqlState, errorCode, sql);
+    }
+
+    /**
+     * Creates a new {@link R2dbcNonTransientResourceException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @param cause     the cause
+     * @since 0.9
+     */
+    public R2dbcNonTransientResourceException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql, @Nullable Throwable cause) {
+        super(reason, sqlState, errorCode, sql, cause);
+    }
+
+    /**
+     * Creates a new {@link R2dbcNonTransientResourceException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
      * @param cause     the cause
      */
-    public R2dbcNonTransientResourceException(@Nullable String reason, @Nullable String sqlState, int errorCode,
-                                              @Nullable Throwable cause) {
+    public R2dbcNonTransientResourceException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable Throwable cause) {
         super(reason, sqlState, errorCode, cause);
     }
 
@@ -82,8 +110,7 @@ public class R2dbcNonTransientResourceException extends R2dbcNonTransientExcepti
      *                 conventions
      * @param cause    the cause
      */
-    public R2dbcNonTransientResourceException(@Nullable String reason, @Nullable String sqlState,
-                                              @Nullable Throwable cause) {
+    public R2dbcNonTransientResourceException(@Nullable String reason, @Nullable String sqlState, @Nullable Throwable cause) {
         super(reason, sqlState, cause);
     }
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcPermissionDeniedException.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcPermissionDeniedException.java
@@ -68,10 +68,38 @@ public class R2dbcPermissionDeniedException extends R2dbcNonTransientException {
      * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
      *                  conventions
      * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @since 0.9
+     */
+    public R2dbcPermissionDeniedException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql) {
+        super(reason, sqlState, errorCode, sql);
+    }
+
+    /**
+     * Creates a new {@link R2dbcPermissionDeniedException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @param cause     the cause
+     * @since 0.9
+     */
+    public R2dbcPermissionDeniedException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql, @Nullable Throwable cause) {
+        super(reason, sqlState, errorCode, sql, cause);
+    }
+
+    /**
+     * Creates a new {@link R2dbcPermissionDeniedException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
      * @param cause     the cause
      */
-    public R2dbcPermissionDeniedException(@Nullable String reason, @Nullable String sqlState, int errorCode,
-                                          @Nullable Throwable cause) {
+    public R2dbcPermissionDeniedException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable Throwable cause) {
         super(reason, sqlState, errorCode, cause);
     }
 
@@ -105,4 +133,5 @@ public class R2dbcPermissionDeniedException extends R2dbcNonTransientException {
     public R2dbcPermissionDeniedException(@Nullable Throwable cause) {
         super(cause);
     }
+
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcRollbackException.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcRollbackException.java
@@ -68,10 +68,38 @@ public class R2dbcRollbackException extends R2dbcTransientException {
      * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
      *                  conventions
      * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @since 0.9
+     */
+    public R2dbcRollbackException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql) {
+        super(reason, sqlState, errorCode, sql);
+    }
+
+    /**
+     * Creates a new {@link R2dbcRollbackException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @param cause     the cause
+     * @since 0.9
+     */
+    public R2dbcRollbackException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql, @Nullable Throwable cause) {
+        super(reason, sqlState, errorCode, sql, cause);
+    }
+
+    /**
+     * Creates a new {@link R2dbcRollbackException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
      * @param cause     the cause
      */
-    public R2dbcRollbackException(@Nullable String reason, @Nullable String sqlState, int errorCode,
-                                  @Nullable Throwable cause) {
+    public R2dbcRollbackException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable Throwable cause) {
         super(reason, sqlState, errorCode, cause);
     }
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcTimeoutException.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcTimeoutException.java
@@ -69,10 +69,38 @@ public class R2dbcTimeoutException extends R2dbcTransientException {
      * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
      *                  conventions
      * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @since 0.9
+     */
+    public R2dbcTimeoutException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql) {
+        super(reason, sqlState, errorCode, sql);
+    }
+
+    /**
+     * Creates a new {@link R2dbcTimeoutException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @param cause     the cause
+     * @since 0.9
+     */
+    public R2dbcTimeoutException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql, @Nullable Throwable cause) {
+        super(reason, sqlState, errorCode, sql, cause);
+    }
+
+    /**
+     * Creates a new {@link R2dbcTimeoutException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
      * @param cause     the cause
      */
-    public R2dbcTimeoutException(@Nullable String reason, @Nullable String sqlState, int errorCode,
-                                 @Nullable Throwable cause) {
+    public R2dbcTimeoutException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable Throwable cause) {
         super(reason, sqlState, errorCode, cause);
     }
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcTransientException.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcTransientException.java
@@ -72,10 +72,38 @@ public abstract class R2dbcTransientException extends R2dbcException {
      * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
      *                  conventions
      * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @since 0.9
+     */
+    public R2dbcTransientException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql) {
+        super(reason, sqlState, errorCode, sql);
+    }
+
+    /**
+     * Creates a new {@link R2dbcTransientException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @param cause     the cause
+     * @since 0.9
+     */
+    public R2dbcTransientException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql, @Nullable Throwable cause) {
+        super(reason, sqlState, errorCode, sql, cause);
+    }
+
+    /**
+     * Creates a new {@link R2dbcTransientException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
      * @param cause     the cause
      */
-    public R2dbcTransientException(@Nullable String reason, @Nullable String sqlState, int errorCode,
-                                   @Nullable Throwable cause) {
+    public R2dbcTransientException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable Throwable cause) {
         super(reason, sqlState, errorCode, cause);
     }
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcTransientResourceException.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/R2dbcTransientResourceException.java
@@ -67,10 +67,38 @@ public class R2dbcTransientResourceException extends R2dbcTransientException {
      * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
      *                  conventions
      * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @since 0.9
+     */
+    public R2dbcTransientResourceException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql) {
+        super(reason, sqlState, errorCode, sql);
+    }
+
+    /**
+     * Creates a new {@link R2dbcTransientResourceException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
+     * @param sql       the SQL statement that caused this error
+     * @param cause     the cause
+     * @since 0.9
+     */
+    public R2dbcTransientResourceException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable String sql, @Nullable Throwable cause) {
+        super(reason, sqlState, errorCode, sql, cause);
+    }
+
+    /**
+     * Creates a new {@link R2dbcTransientResourceException}.
+     *
+     * @param reason    the reason for the error.  Set as the exception's message and retrieved with {@link #getMessage()}.
+     * @param sqlState  the "SQLState" string, which follows either the XOPEN SQLState conventions or the SQL:2003
+     *                  conventions
+     * @param errorCode a vendor-specific error code representing this failure
      * @param cause     the cause
      */
-    public R2dbcTransientResourceException(@Nullable String reason, @Nullable String sqlState, int errorCode,
-                                           @Nullable Throwable cause) {
+    public R2dbcTransientResourceException(@Nullable String reason, @Nullable String sqlState, int errorCode, @Nullable Throwable cause) {
         super(reason, sqlState, errorCode, cause);
     }
 
@@ -82,8 +110,7 @@ public class R2dbcTransientResourceException extends R2dbcTransientException {
      *                 conventions
      * @param cause    the cause
      */
-    public R2dbcTransientResourceException(@Nullable String reason, @Nullable String sqlState,
-                                           @Nullable Throwable cause) {
+    public R2dbcTransientResourceException(@Nullable String reason, @Nullable String sqlState, @Nullable Throwable cause) {
         super(reason, sqlState, cause);
     }
 


### PR DESCRIPTION
`R2dbcException` and subclasses now accept the offending SQL that has lead to the exception. The SQL isn't included in the toString representation to not disclose potentially sensitive data in unintended places such as logs.

[resolves #238]