### PR TITLE
Refine exception specification when accessing items by name/by index.

### DIFF
--- a/r2dbc-spec/src/main/asciidoc/exceptions.adoc
+++ b/r2dbc-spec/src/main/asciidoc/exceptions.adoc
@@ -20,13 +20,25 @@ R2DBC defines the following general exceptions:
 [[exceptions.iae]]
 === `IllegalArgumentException`
 
-Drivers throw `IllegalArgumentException` if a method has been received an illegal or inappropriate argument (such as values that are out of bounds or an expected parameter is `null`).
+Drivers throw `IllegalArgumentException` if a method has received an illegal or inappropriate argument (such as values that are invalid or an expected parameter is `null`).
+This exception is a generic exception that is not associated with an error code or an `SQLState`.
+
+[[exceptions.iob]]
+=== `IndexOutOfBoundsException`
+
+Drivers throw `IndexOutOfBoundsException` if a method has received an illegal or inappropriate index value (such as negative values or indexes that are greater or equal to the number of elements).
 This exception is a generic exception that is not associated with an error code or an `SQLState`.
 
 [[exceptions.ise]]
 === `IllegalStateException`
 
 Drivers throw `IllegalStateException` if a method has received an argument that is invalid in the current state or when an argument-less method is invoked in a state that does not allow execution in the current state (such as interacting with a closed connection object).
+This exception is a generic exception that is not associated with an error code or an `SQLState`.
+
+[[exceptions.nse]]
+=== `NoSuchElementException`
+
+Drivers throw `NoSuchElementException` if a method has received a column/parameter name that doesn't exist in the collection of items.
 This exception is a generic exception that is not associated with an error code or an `SQLState`.
 
 [[exceptions.nsoe]]

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/OutParametersMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/OutParametersMetadata.java
@@ -31,7 +31,7 @@ public interface OutParametersMetadata {
      *
      * @param index the out parameter index starting at 0
      * @return the {@link OutParameterMetadata} for one out parameter
-     * @throws ArrayIndexOutOfBoundsException if the {@code index} is less than zero or greater than the number of available out parameters.
+     * @throws IndexOutOfBoundsException if {@code index} is out of range (negative or equals/exceeds {@code getParameterMetadatas().size()})
      */
     OutParameterMetadata getParameterMetadata(int index);
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Readable.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Readable.java
@@ -16,6 +16,8 @@
 
 package io.r2dbc.spi;
 
+import java.util.NoSuchElementException;
+
 /**
  * Represents a readable object, for example a set of columns or {@code OUT} parameters from a database query, later on referred to as items.
  * Values can for columns or {@code OUT} parameters be either retrieved by specifying a name or the index.
@@ -44,6 +46,7 @@ public interface Readable {
      *
      * @param index the index of the parameter starting at {@code 0}
      * @return the value.  Value can be {@code null}.
+     * @throws IndexOutOfBoundsException if {@code index} if the index is out of range (negative or equals/exceeds the number of readable objects)
      */
     @Nullable
     default Object get(int index) {
@@ -57,7 +60,8 @@ public interface Readable {
      * @param type  the type of item to return.  This type must be assignable to, and allows for variance.
      * @param <T>   the type of the item being returned.
      * @return the value.  Value can be {@code null}.
-     * @throws IllegalArgumentException if {@code type} is {@code null}
+     * @throws IllegalArgumentException  if {@code type} is {@code null}
+     * @throws IndexOutOfBoundsException if {@code index} is out of range (negative or equals/exceeds the number of readable objects)
      */
     @Nullable
     <T> T get(int index, Class<T> type);
@@ -69,6 +73,7 @@ public interface Readable {
      * @param name the name
      * @return the value.  Value can be {@code null}.
      * @throws IllegalArgumentException if {@code name} is {@code null}
+     * @throws NoSuchElementException   if {@code name} is not a known readable column or out parameter
      */
     @Nullable
     default Object get(String name) {
@@ -83,6 +88,7 @@ public interface Readable {
      * @param <T>  the type of the item being returned.
      * @return the value.  Value can be {@code null}.
      * @throws IllegalArgumentException if {@code name} or {@code type} is {@code null}
+     * @throws NoSuchElementException if {@code name} is not a known readable column or out parameter
      */
     @Nullable
     <T> T get(String name, Class<T> type);

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/RowMetadata.java
@@ -33,7 +33,7 @@ public interface RowMetadata {
      *
      * @param index the column index starting at 0
      * @return the {@link ColumnMetadata} for one column in this row
-     * @throws ArrayIndexOutOfBoundsException if the {@code index} is less than zero or greater than the number of available columns.
+     * @throws IndexOutOfBoundsException if {@code index} is out of range (negative or equals/exceeds {@code getColumnMetadatas().size()})
      */
     ColumnMetadata getColumnMetadata(int index);
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Statement.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Statement.java
@@ -18,6 +18,8 @@ package io.r2dbc.spi;
 
 import org.reactivestreams.Publisher;
 
+import java.util.NoSuchElementException;
+
 /**
  * A statement that can be executed multiple times in a prepared and optimized way.  Bound parameters can be either scalar values (using type inference for the database parameter type) or
  * {@link Parameter} objects.
@@ -64,6 +66,7 @@ public interface Statement {
      * @param value the value to bind
      * @return this {@link Statement}
      * @throws IllegalArgumentException if {@code name} or {@code value} is {@code null}
+     * @throws NoSuchElementException   if {@code name} is not a known name to bind
      */
     Statement bind(String name, Object value);
 
@@ -85,6 +88,7 @@ public interface Statement {
      * @param type the type of null value
      * @return this {@link Statement}
      * @throws IllegalArgumentException if {@code name} or {@code type} is {@code null}
+     * @throws NoSuchElementException if {@code name} is not a known name to bind
      */
     Statement bindNull(String name, Class<?> type);
 


### PR DESCRIPTION
We now define `IndexOutOfBoundsException` to signal out of range indexes for by-index access and `NoSuchElementException` to signal unknown/illegal identifiers for by-name access to columns, out parameters, and bind values.

[resolves #184]