### PR TITLE
correct test to avoid using ByteBuffer.array comparison.

### DIFF
--- a/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/TestKit.java
+++ b/r2dbc-spi-test/src/main/java/io/r2dbc/spi/test/TestKit.java
@@ -421,7 +421,7 @@ public interface TestKit<T> {
 
             @Override
             protected void setValues(PreparedStatement ps, LobCreator lobCreator) throws SQLException {
-                lobCreator.setBlobAsBytes(ps, 1, StandardCharsets.UTF_8.encode("test-value").array());
+                lobCreator.setBlobAsBytes(ps, 1, "test-value".getBytes(StandardCharsets.UTF_8));
             }
 
         });
@@ -443,7 +443,7 @@ public interface TestKit<T> {
                 Connection::close)
             .as(StepVerifier::create)
             .expectNextMatches(actual -> {
-                ByteBuffer expected = StandardCharsets.UTF_8.encode("test-value");
+                ByteBuffer expected = ByteBuffer.wrap("test-value".getBytes(StandardCharsets.UTF_8));
                 return Arrays.equals(expected.array(), actual);
             })
             .verifyComplete();
@@ -462,7 +462,7 @@ public interface TestKit<T> {
             .as(StepVerifier::create)
             .expectNextMatches(actual -> {
                 ByteBuffer expected = StandardCharsets.UTF_8.encode("test-value");
-                return Arrays.equals(expected.array(), actual.array());
+                return actual.compareTo(expected) == 0;
             })
             .verifyComplete();
     }


### PR DESCRIPTION
#### Issue description

Testkit correction: 

backing array ByteBuffer.array may not exactly represent UTF8 encoded bytes.
PR permit to ensure test is valid whatever the JVM is used

Example using jdk8:
  * "test-value".getBytes(StandardCharsets.UTF_8) => 0x746573742D76616C7565
  * StandardCharsets.UTF_8.encode("test-value").array() => 0x746573742D76616C756500 having an additional ending 0x00


Signed-off-by: diego Dupin<diego.dupin@gmail.com>