### PR TITLE
Removed copy paste artifact from Javadoc

### DIFF
--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Result.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Result.java
@@ -178,7 +178,7 @@ public interface Result {
         /**
          * Returns the message text.
          *
-         * @return the message text.                                                                                MockResult.java
+         * @return the message text.
          */
         String message();
 


### PR DESCRIPTION
There seems to be a copy paste artifact in the Javadoc that seems unnecessary