### PR TITLE
Feature/dynamic credential

### DIFF
--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/ConnectionFactoryOptions.java
@@ -16,6 +16,8 @@
 
 package io.r2dbc.spi;
 
+import org.reactivestreams.Publisher;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -105,6 +107,11 @@ public final class ConnectionFactoryOptions {
      * @since 0.9
      */
     public static final Option<Duration> STATEMENT_TIMEOUT = Option.valueOf("statementTimeout");
+
+    /**
+     * A Credential publisher, which supports dynamic credential usage.
+     */
+    public static final Option<Publisher<? extends Credential>> CREDENTIAL_PUBLISHER = Option.valueOf("credentialPublisher");
 
     /**
      * User for authentication.

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Credential.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Credential.java
@@ -1,0 +1,11 @@
+package io.r2dbc.spi;
+
+/**
+ * Credentials used to authenticate with a database. Credential objects are
+ * mutable. Mutability allows any security sensitive values retained by a
+ * {@code Credential} to be cleared from memory. Drivers MUST NOT retain a
+ * reference to a {@code Credential} object after consuming it for database
+ * authentication.
+ */
+interface Credential {
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/CredentialFactory.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/CredentialFactory.java
@@ -1,7 +1,9 @@
 package io.r2dbc.spi;
 
 /** Factory for creating {@link Credential} objects */
-public class CredentialFactory {
+public final class CredentialFactory {
+
+    private CredentialFactory() { }
 
     /**
      * Returns a new {@link UserPasswordCredential}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/CredentialFactory.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/CredentialFactory.java
@@ -1,0 +1,16 @@
+package io.r2dbc.spi;
+
+/** Factory for creating {@link Credential} objects */
+public class CredentialFactory {
+
+    /**
+     * Returns a new {@link UserPasswordCredential}
+     * @param user Username. Not null.
+     * @param password Password. Not null.
+     */
+    public static UserPasswordCredential createUserPasswordCredential(
+            String user, CharSequence password) {
+        return new UserPasswordCredentialImpl(user, password);
+    }
+
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/Result.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/Result.java
@@ -178,7 +178,7 @@ public interface Result {
         /**
          * Returns the message text.
          *
-         * @return the message text.                                                                                MockResult.java
+         * @return the message text.
          */
         String message();
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/UserPasswordCredential.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/UserPasswordCredential.java
@@ -4,6 +4,18 @@ package io.r2dbc.spi;
  * UserPasswordCredentials used to authenticate with a database.
  */
 public interface UserPasswordCredential extends Credential {
+
+    /**
+     * Returns the user of the {@link UserPasswordCredential}.
+     *
+     * @return the user of the {@link UserPasswordCredential}.
+     */
     String user();
+
+    /**
+     * Returns the password of the {@link UserPasswordCredential}.
+     *
+     * @return the password of the {@link UserPasswordCredential}.
+     */
     CharSequence password();
 }

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/UserPasswordCredential.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/UserPasswordCredential.java
@@ -1,0 +1,9 @@
+package io.r2dbc.spi;
+
+/**
+ * UserPasswordCredentials used to authenticate with a database.
+ */
+public interface UserPasswordCredential extends Credential {
+    String user();
+    CharSequence password();
+}

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/UserPasswordCredentialImpl.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/UserPasswordCredentialImpl.java
@@ -1,6 +1,6 @@
 package io.r2dbc.spi;
 
-public class UserPasswordCredentialImpl implements UserPasswordCredential {
+class UserPasswordCredentialImpl implements UserPasswordCredential {
 
     private String user;
 

--- a/r2dbc-spi/src/main/java/io/r2dbc/spi/UserPasswordCredentialImpl.java
+++ b/r2dbc-spi/src/main/java/io/r2dbc/spi/UserPasswordCredentialImpl.java
@@ -1,0 +1,23 @@
+package io.r2dbc.spi;
+
+public class UserPasswordCredentialImpl implements UserPasswordCredential {
+
+    private String user;
+
+    private CharSequence password;
+
+    UserPasswordCredentialImpl(String user, CharSequence password) {
+        this.user = user;
+        this.password = password;
+    }
+
+    @Override
+    public String user() {
+        return this.user;
+    }
+
+    @Override
+    public CharSequence password() {
+        return this.password;
+    }
+}


### PR DESCRIPTION

Added this pull request implementing @Michael-A-McMahon 's suggested changes for #273 .

Only difference vs original suggestions on #273 is using a class for `UserPasswordCredentialImpl` rather than a `record`, so as not to tie the project to java 14. 

Still need to add tests for this, was having trouble getting r2dbc-spi-test module running in my local env...